### PR TITLE
Added support for Key parameter in image() and svg()

### DIFF
--- a/example/lib/gen/assets.gen.dart
+++ b/example/lib/gen/assets.gen.dart
@@ -69,6 +69,7 @@ class AssetGenImage extends AssetImage {
   final String _assetName;
 
   Image image({
+    Key key,
     ImageFrameBuilder frameBuilder,
     ImageLoadingBuilder loadingBuilder,
     ImageErrorWidgetBuilder errorBuilder,
@@ -88,6 +89,7 @@ class AssetGenImage extends AssetImage {
     FilterQuality filterQuality = FilterQuality.low,
   }) {
     return Image(
+      key: key,
       image: this,
       frameBuilder: frameBuilder,
       loadingBuilder: loadingBuilder,
@@ -118,6 +120,7 @@ class SvgGenImage {
   final String _assetName;
 
   SvgPicture svg({
+    Key key,
     bool matchTextDirection = false,
     AssetBundle bundle,
     String package,
@@ -135,6 +138,7 @@ class SvgGenImage {
   }) {
     return SvgPicture.asset(
       _assetName,
+      key: key,
       matchTextDirection: matchTextDirection,
       bundle: bundle,
       package: package,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,13 +23,14 @@ void main() {
             children: <Widget>[
               // Auto generated image from FlutterGen.
               Image(image: Assets.images.chip1),
-              Assets.images.icons.kmm.svg(),
+              Assets.images.icons.kmm.svg(key: Key("kmm_svg")),
               Assets.images.icons.fuchsia.svg(),
               Assets.images.icons.paint.svg(
                 width: 120,
                 height: 120,
               ),
               Assets.pictures.chip5.image(
+                key: Key("chip5"),
                 width: 120,
                 height: 120,
                 fit: BoxFit.scaleDown,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   build:
     dependency: transitive
     description:
@@ -98,14 +98,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   code_builder:
     dependency: transitive
     description:
@@ -140,7 +140,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   color:
     dependency: transitive
     description:
@@ -189,7 +189,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   fixnum:
     dependency: transitive
     description:
@@ -208,7 +208,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.2.1"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -290,14 +290,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   mime:
     dependency: transitive
     description:
@@ -332,7 +332,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   path_drawing:
     dependency: transitive
     description:
@@ -414,21 +414,21 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   stream_transform:
     dependency: transitive
     description:
@@ -442,21 +442,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   time:
     dependency: transitive
     description:
@@ -477,14 +477,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
   watcher:
     dependency: transitive
     description:
@@ -514,5 +514,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.9.0 <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.20.0 <2.0.0"

--- a/lib/src/generators/assets_generator.dart
+++ b/lib/src/generators/assets_generator.dart
@@ -308,6 +308,7 @@ class AssetGenImage extends AssetImage {
   final String _assetName;
 
   Image image({
+    Key key,
     ImageFrameBuilder frameBuilder,
     ImageLoadingBuilder loadingBuilder,
     ImageErrorWidgetBuilder errorBuilder,
@@ -327,6 +328,7 @@ class AssetGenImage extends AssetImage {
     FilterQuality filterQuality = FilterQuality.low,
   }) {
     return Image(
+      key: key,
       image: this,
       frameBuilder: frameBuilder,
       loadingBuilder: loadingBuilder,

--- a/lib/src/generators/integrations/svg_integration.dart
+++ b/lib/src/generators/integrations/svg_integration.dart
@@ -14,6 +14,7 @@ class SvgIntegration extends Integration {
   final String _assetName;
 
   SvgPicture svg({
+    Key key,
     bool matchTextDirection = false,
     AssetBundle bundle,
     String package,
@@ -31,6 +32,7 @@ class SvgIntegration extends Integration {
   }) {
     return SvgPicture.asset(
       _assetName,
+      key: key,
       matchTextDirection: matchTextDirection,
       bundle: bundle,
       package: package,

--- a/test_resources/actual_data/assets.gen.dart
+++ b/test_resources/actual_data/assets.gen.dart
@@ -69,6 +69,7 @@ class AssetGenImage extends AssetImage {
   final String _assetName;
 
   Image image({
+    Key key,
     ImageFrameBuilder frameBuilder,
     ImageLoadingBuilder loadingBuilder,
     ImageErrorWidgetBuilder errorBuilder,
@@ -88,6 +89,7 @@ class AssetGenImage extends AssetImage {
     FilterQuality filterQuality = FilterQuality.low,
   }) {
     return Image(
+      key: key,
       image: this,
       frameBuilder: frameBuilder,
       loadingBuilder: loadingBuilder,
@@ -118,6 +120,7 @@ class SvgGenImage {
   final String _assetName;
 
   SvgPicture svg({
+    Key key,
     bool matchTextDirection = false,
     AssetBundle bundle,
     String package,
@@ -135,6 +138,7 @@ class SvgGenImage {
   }) {
     return SvgPicture.asset(
       _assetName,
+      key: key,
       matchTextDirection: matchTextDirection,
       bundle: bundle,
       package: package,

--- a/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/test_resources/actual_data/assets_camel_case.gen.dart
@@ -35,6 +35,7 @@ class AssetGenImage extends AssetImage {
   final String _assetName;
 
   Image image({
+    Key key,
     ImageFrameBuilder frameBuilder,
     ImageLoadingBuilder loadingBuilder,
     ImageErrorWidgetBuilder errorBuilder,
@@ -54,6 +55,7 @@ class AssetGenImage extends AssetImage {
     FilterQuality filterQuality = FilterQuality.low,
   }) {
     return Image(
+      key: key,
       image: this,
       frameBuilder: frameBuilder,
       loadingBuilder: loadingBuilder,

--- a/test_resources/actual_data/assets_no_integrations.gen.dart
+++ b/test_resources/actual_data/assets_no_integrations.gen.dart
@@ -66,6 +66,7 @@ class AssetGenImage extends AssetImage {
   final String _assetName;
 
   Image image({
+    Key key,
     ImageFrameBuilder frameBuilder,
     ImageLoadingBuilder loadingBuilder,
     ImageErrorWidgetBuilder errorBuilder,
@@ -85,6 +86,7 @@ class AssetGenImage extends AssetImage {
     FilterQuality filterQuality = FilterQuality.low,
   }) {
     return Image(
+      key: key,
       image: this,
       frameBuilder: frameBuilder,
       loadingBuilder: loadingBuilder,

--- a/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/test_resources/actual_data/assets_snake_case.gen.dart
@@ -35,6 +35,7 @@ class AssetGenImage extends AssetImage {
   final String _assetName;
 
   Image image({
+    Key key,
     ImageFrameBuilder frameBuilder,
     ImageLoadingBuilder loadingBuilder,
     ImageErrorWidgetBuilder errorBuilder,
@@ -54,6 +55,7 @@ class AssetGenImage extends AssetImage {
     FilterQuality filterQuality = FilterQuality.low,
   }) {
     return Image(
+      key: key,
       image: this,
       frameBuilder: frameBuilder,
       loadingBuilder: loadingBuilder,


### PR DESCRIPTION
### What does this change?
Add support to specify a Key for convenience methods image() and svg().

### What is the value of this and can you measure success?
Clients who need to assign a key to the Image or SvgPicture could use the convenience methods like Assets.images.my_image.image(key: Key("mykey")), rather than forcing them to do something like Image(key: Key("mykey"), Assets.images.my_image).
