### PR TITLE
chore(generator): workaround nnbd #75

### DIFF
--- a/packages/core/lib/generators/generator_helper.dart
+++ b/packages/core/lib/generators/generator_helper.dart
@@ -1,5 +1,6 @@
 String get header {
-  return '''/// GENERATED CODE - DO NOT MODIFY BY HAND
+  return '''// @dart = 2.10
+/// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
 /// *****************************************************

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/colors.gen.dart
+++ b/packages/core/test_resources/actual_data/colors.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen

--- a/packages/core/test_resources/actual_data/fonts.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts.gen.dart
@@ -1,3 +1,4 @@
+// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen


### PR DESCRIPTION
### What does this change?

Fixed: Issue #75 

**MEMO**
If when forgot to add `--no-sound-null-safety` argument,
```
Xcode's output:
↳
    lib/gen/assets.gen.dart:1:1: Error: A library can't opt out of null safety by default, when using sound null safety.
    // @dart = 2.10
    ^^^^^^^^^^^^^^^
    lib/gen/colors.gen.dart:1:1: Error: A library can't opt out of null safety by default, when using sound null safety.
    // @dart = 2.10
    ^^^^^^^^^^^^^^^
    lib/gen/fonts.gen.dart:1:1: Error: A library can't opt out of null safety by default, when using sound null safety.
    // @dart = 2.10
```

### What is the value of this and can you measure success?

- Pass CI