### PR TITLE
Support for adding assets from a package

### DIFF
--- a/example/lib/gen/assets.gen.dart
+++ b/example/lib/gen/assets.gen.dart
@@ -82,6 +82,8 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
+  static const package = 'example';
+
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
@@ -93,7 +95,7 @@ class Assets {
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'example');
   final String _assetName;
 
   Image image({
@@ -151,7 +153,7 @@ class SvgGenImage {
     Key? key,
     bool matchTextDirection = false,
     AssetBundle? bundle,
-    String? package,
+    String? package = 'example',
     double? width,
     double? height,
     BoxFit fit = BoxFit.contain,

--- a/example/lib/gen/assets.gen.dart
+++ b/example/lib/gen/assets.gen.dart
@@ -82,8 +82,6 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
-  static const package = 'example';
-
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -219,9 +219,9 @@ packages:
   flutter_gen_core:
     dependency: transitive
     description:
-      path: "../packages/core"
-      relative: true
-    source: path
+      name: flutter_gen_core
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "3.0.2"
   flutter_gen_runner:
     dependency: "direct dev"

--- a/packages/command/pubspec.lock
+++ b/packages/command/pubspec.lock
@@ -102,9 +102,9 @@ packages:
   flutter_gen_core:
     dependency: "direct main"
     description:
-      name: flutter_gen_core
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../core"
+      relative: true
+    source: path
     version: "3.0.2"
   glob:
     dependency: transitive

--- a/packages/command/pubspec.yaml
+++ b/packages/command/pubspec.yaml
@@ -23,3 +23,6 @@ dependencies:
 dev_dependencies:
   effective_dart: '>=1.3.0 <2.0.0'
 
+dependency_overrides:
+  flutter_gen_core:
+    path: ../core

--- a/packages/core/lib/flutter_generator.dart
+++ b/packages/core/lib/flutter_generator.dart
@@ -37,7 +37,6 @@ class FlutterGenerator {
 
     final output = config.flutterGen.output;
     final lineLength = config.flutterGen.lineLength;
-    final nullSafety = config.flutterGen.nullSafety;
     final formatter = DartFormatter(pageWidth: lineLength, lineEnding: '\n');
 
     final absoluteOutput =
@@ -58,8 +57,9 @@ class FlutterGenerator {
 
     if (config.flutterGen.assets.enabled && config.flutter.assets.isNotEmpty) {
       final generated = generateAssets(
-          pubspecFile, formatter, config.flutterGen, config.flutter.assets,
-          nullSafety: nullSafety);
+        AssetsGenConfig.fromConfig(pubspecFile, config),
+        formatter,
+      );
       final assets =
           File(normalize(join(pubspecFile.parent.path, output, assetsName)));
       writeAsString(generated, file: assets);

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -244,8 +244,7 @@ String _dotDelimiterStyleDefinition(
       assetTypeQueue.addAll(assetType.children);
     }
   }
-  buffer.writeln(
-      _assetsClassDefinition(config.packageName, assetsStaticStatements));
+  buffer.writeln(_assetsClassDefinition(assetsStaticStatements));
   return buffer.toString();
 }
 
@@ -301,18 +300,16 @@ String _flatStyleDefinition(
       )
       .whereType<_Statement>()
       .toList();
-  return _assetsClassDefinition(config.packageName, statements);
+  return _assetsClassDefinition(statements);
 }
 
-String _assetsClassDefinition(String packageName, List<_Statement> statements) {
+String _assetsClassDefinition(List<_Statement> statements) {
   final statementsBlock = statements
       .map((statement) => '  ${statement.toStaticFieldString()}')
       .join('\n');
   return '''
 class Assets {
   Assets._();
-  
-  static const package = '$packageName';
   
   $statementsBlock
 }

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -6,6 +6,7 @@ import 'package:dartx/dartx.dart';
 import 'package:path/path.dart';
 
 import '../settings/asset_type.dart';
+import '../settings/config.dart';
 import '../settings/pubspec.dart';
 import '../utils/dart_style/dart_style.dart';
 import '../utils/error.dart';
@@ -15,17 +16,34 @@ import 'integrations/flare_integration.dart';
 import 'integrations/integration.dart';
 import 'integrations/svg_integration.dart';
 
-String generateAssets(
-  File pubspecFile,
-  DartFormatter formatter,
-  FlutterGen flutterGen,
-  List<String> assets, {
+class AssetsGenConfig {
+  AssetsGenConfig._(
+    this.rootPath,
+    this.packageName,
+    this.flutterGen,
+    this.assets,
+  );
 
-  // TODO: Until null safety generalizes
-  // ignore: type_annotate_public_apis
-  nullSafety = true,
-}) {
-  if (assets.isEmpty) {
+  factory AssetsGenConfig.fromConfig(File pubspecFile, Config config) {
+    return AssetsGenConfig._(
+      pubspecFile.parent.path,
+      config.pubspec.packageName,
+      config.pubspec.flutterGen,
+      config.pubspec.flutter.assets,
+    );
+  }
+
+  final String rootPath;
+  final String packageName;
+  final FlutterGen flutterGen;
+  final List<String> assets;
+}
+
+String generateAssets(
+  AssetsGenConfig config,
+  DartFormatter formatter,
+) {
+  if (config.assets.isEmpty) {
     throw InvalidSettingsException(
         'The value of "flutter/assets:" is incorrect.');
   }
@@ -35,30 +53,29 @@ String generateAssets(
 
   final integrations = <Integration>[
     // TODO: Until null safety generalizes
-    if (flutterGen.integrations.flutterSvg)
-      SvgIntegration(nullSafety: nullSafety),
-    if (flutterGen.integrations.flareFlutter)
-      FlareIntegration(nullSafety: nullSafety),
+    if (config.flutterGen.integrations.flutterSvg)
+      SvgIntegration(config.packageName,
+          nullSafety: config.flutterGen.nullSafety),
+    if (config.flutterGen.integrations.flareFlutter)
+      FlareIntegration(nullSafety: config.flutterGen.nullSafety),
   ];
 
-  if (flutterGen.assets.isDotDelimiterStyle) {
-    classesBuffer.writeln(
-        _dotDelimiterStyleDefinition(pubspecFile, assets, integrations));
-  } else if (flutterGen.assets.isSnakeCaseStyle) {
-    classesBuffer
-        .writeln(_snakeCaseStyleDefinition(pubspecFile, assets, integrations));
-  } else if (flutterGen.assets.isCamelCaseStyle) {
-    classesBuffer
-        .writeln(_camelCaseStyleDefinition(pubspecFile, assets, integrations));
+  if (config.flutterGen.assets.isDotDelimiterStyle) {
+    classesBuffer.writeln(_dotDelimiterStyleDefinition(config, integrations));
+  } else if (config.flutterGen.assets.isSnakeCaseStyle) {
+    classesBuffer.writeln(_snakeCaseStyleDefinition(config, integrations));
+  } else if (config.flutterGen.assets.isCamelCaseStyle) {
+    classesBuffer.writeln(_camelCaseStyleDefinition(config, integrations));
   } else {
     throw 'The value of "flutter_gen/assets/style." is incorrect.';
   }
 
   // TODO: Until null safety generalizes
-  if (nullSafety) {
-    classesBuffer.writeln(_assetGenImageClassDefinition);
+  if (config.flutterGen.nullSafety) {
+    classesBuffer.writeln(_assetGenImageClassDefinition(config.packageName));
   } else {
-    classesBuffer.writeln(_assetGenImageClassDefinitionWithNoNullSafety);
+    classesBuffer.writeln(
+        _assetGenImageClassDefinitionWithNoNullSafety(config.packageName));
   }
 
   final imports = <String>{'package:flutter/widgets.dart'};
@@ -75,7 +92,7 @@ String generateAssets(
   final buffer = StringBuffer();
 
   // TODO: Until null safety generalizes
-  if (nullSafety) {
+  if (config.flutterGen.nullSafety) {
     buffer.writeln(header);
   } else {
     buffer.writeln(headerWithNoNullSafety);
@@ -86,21 +103,20 @@ String generateAssets(
 }
 
 List<String> _getAssetRelativePathList(
-  File pubspecFile,
+  String rootPath,
   List<String> assets,
 ) {
   final assetRelativePathList = <String>[];
   for (final assetName in assets) {
-    final assetAbsolutePath = join(pubspecFile.parent.path, assetName);
+    final assetAbsolutePath = join(rootPath, assetName);
     if (FileSystemEntity.isDirectorySync(assetAbsolutePath)) {
       assetRelativePathList.addAll(Directory(assetAbsolutePath)
           .listSync()
           .whereType<File>()
-          .map((e) => relative(e.path, from: pubspecFile.parent.path))
+          .map((e) => relative(e.path, from: rootPath))
           .toList());
     } else if (FileSystemEntity.isFileSync(assetAbsolutePath)) {
-      assetRelativePathList
-          .add(relative(assetAbsolutePath, from: pubspecFile.parent.path));
+      assetRelativePathList.add(relative(assetAbsolutePath, from: rootPath));
     }
   }
   return assetRelativePathList;
@@ -130,12 +146,12 @@ AssetType _constructAssetTree(List<String> assetRelativePathList) {
 }
 
 _Statement? _createAssetTypeStatement(
-  File pubspecFile,
+  String rootPath,
   AssetType assetType,
   List<Integration> integrations,
   String name,
 ) {
-  final childAssetAbsolutePath = join(pubspecFile.parent.path, assetType.path);
+  final childAssetAbsolutePath = join(rootPath, assetType.path);
   if (assetType.isSupportedImage) {
     return _Statement(
       type: 'AssetGenImage',
@@ -176,12 +192,12 @@ _Statement? _createAssetTypeStatement(
 
 /// Generate style like Assets.foo.bar
 String _dotDelimiterStyleDefinition(
-  File pubspecFile,
-  List<String> assets,
+  AssetsGenConfig config,
   List<Integration> integrations,
 ) {
   final buffer = StringBuffer();
-  final assetRelativePathList = _getAssetRelativePathList(pubspecFile, assets);
+  final assetRelativePathList =
+      _getAssetRelativePathList(config.rootPath, config.assets);
   final assetsStaticStatements = <_Statement>[];
 
   final assetTypeQueue = ListQueue<AssetType>.from(
@@ -189,14 +205,14 @@ String _dotDelimiterStyleDefinition(
 
   while (assetTypeQueue.isNotEmpty) {
     final assetType = assetTypeQueue.removeFirst();
-    final assetAbsolutePath = join(pubspecFile.parent.path, assetType.path);
+    final assetAbsolutePath = join(config.rootPath, assetType.path);
 
     if (FileSystemEntity.isDirectorySync(assetAbsolutePath)) {
       final statements = assetType.children
           .mapToIsUniqueWithoutExtension()
           .map(
             (e) => _createAssetTypeStatement(
-              pubspecFile,
+              config.rootPath,
               e.assetType,
               integrations,
               (e.isUniqueWithoutExtension
@@ -228,19 +244,18 @@ String _dotDelimiterStyleDefinition(
       assetTypeQueue.addAll(assetType.children);
     }
   }
-  buffer.writeln(_assetsClassDefinition(assetsStaticStatements));
+  buffer.writeln(
+      _assetsClassDefinition(config.packageName, assetsStaticStatements));
   return buffer.toString();
 }
 
 /// Generate style like Assets.fooBar
 String _camelCaseStyleDefinition(
-  File pubspecFile,
-  List<String> assets,
+  AssetsGenConfig config,
   List<Integration> integrations,
 ) {
   return _flatStyleDefinition(
-    pubspecFile,
-    assets,
+    config,
     integrations,
     (e) => (e.isUniqueWithoutExtension
             ? withoutExtension(e.assetType.path)
@@ -252,13 +267,11 @@ String _camelCaseStyleDefinition(
 
 /// Generate style like Assets.foo_bar
 String _snakeCaseStyleDefinition(
-  File pubspecFile,
-  List<String> assets,
+  AssetsGenConfig config,
   List<Integration> integrations,
 ) {
   return _flatStyleDefinition(
-    pubspecFile,
-    assets,
+    config,
     integrations,
     (e) => (e.isUniqueWithoutExtension
             ? withoutExtension(e.assetType.path)
@@ -269,19 +282,18 @@ String _snakeCaseStyleDefinition(
 }
 
 String _flatStyleDefinition(
-  File pubspecFile,
-  List<String> assets,
+  AssetsGenConfig config,
   List<Integration> integrations,
   String Function(AssetTypeIsUniqueWithoutExtension) createName,
 ) {
-  final statements = _getAssetRelativePathList(pubspecFile, assets)
+  final statements = _getAssetRelativePathList(config.rootPath, config.assets)
       .distinct()
       .sorted()
       .map((relativePath) => AssetType(relativePath))
       .mapToIsUniqueWithoutExtension()
       .map(
         (e) => _createAssetTypeStatement(
-          pubspecFile,
+          config.rootPath,
           e.assetType,
           integrations,
           createName(e),
@@ -289,16 +301,18 @@ String _flatStyleDefinition(
       )
       .whereType<_Statement>()
       .toList();
-  return _assetsClassDefinition(statements);
+  return _assetsClassDefinition(config.packageName, statements);
 }
 
-String _assetsClassDefinition(List<_Statement> statements) {
+String _assetsClassDefinition(String packageName, List<_Statement> statements) {
   final statementsBlock = statements
       .map((statement) => '  ${statement.toStaticFieldString()}')
       .join('\n');
   return '''
 class Assets {
   Assets._();
+  
+  static const package = '$packageName';
   
   $statementsBlock
 }
@@ -322,12 +336,12 @@ class $className {
 }
 
 /// Null Safety
-const String _assetGenImageClassDefinition = '''
+String _assetGenImageClassDefinition(String packageName) => '''
 
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: '$packageName');
   final String _assetName;
 
   Image image({
@@ -379,12 +393,12 @@ class AssetGenImage extends AssetImage {
 
 /// No Null Safety
 /// TODO: Until null safety generalizes
-const String _assetGenImageClassDefinitionWithNoNullSafety = '''
+String _assetGenImageClassDefinitionWithNoNullSafety(String packageName) => '''
 
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: '$packageName');
   final String _assetName;
 
   Image image({

--- a/packages/core/lib/generators/integrations/svg_integration.dart
+++ b/packages/core/lib/generators/integrations/svg_integration.dart
@@ -4,7 +4,10 @@ import 'integration.dart';
 class SvgIntegration extends Integration {
   // TODO: Until null safety generalizes
   // ignore: avoid_positional_boolean_parameters
-  SvgIntegration({bool nullSafety = true}) : super(nullSafety: nullSafety);
+  SvgIntegration(this._packageName, {bool nullSafety = true})
+      : super(nullSafety: nullSafety);
+
+  final String _packageName;
 
   @override
   List<String> get requiredImports => [
@@ -18,7 +21,7 @@ class SvgIntegration extends Integration {
       nullSafety ? _classDefinition : _classDefinitionWithNoNullSafety;
 
   /// Null Safety
-  final String _classDefinition = '''class SvgGenImage {
+  String get _classDefinition => '''class SvgGenImage {
   const SvgGenImage(this._assetName);
 
   final String _assetName;
@@ -27,7 +30,7 @@ class SvgIntegration extends Integration {
     Key? key,
     bool matchTextDirection = false,
     AssetBundle? bundle,
-    String? package,
+    String? package = '$_packageName',
     double? width,
     double? height,
     BoxFit fit = BoxFit.contain,
@@ -65,7 +68,7 @@ class SvgIntegration extends Integration {
 
   /// No Null Safety
   /// TODO: Until null safety generalizes
-  final String _classDefinitionWithNoNullSafety = '''class SvgGenImage {
+  String get _classDefinitionWithNoNullSafety => '''class SvgGenImage {
   const SvgGenImage(this._assetName);
 
   final String _assetName;
@@ -74,7 +77,7 @@ class SvgIntegration extends Integration {
     Key key,
     bool matchTextDirection = false,
     AssetBundle bundle,
-    String package,
+    String package = '$_packageName',
     double width,
     double height,
     BoxFit fit = BoxFit.contain,

--- a/packages/core/lib/settings/config.dart
+++ b/packages/core/lib/settings/config.dart
@@ -9,10 +9,12 @@ import 'pubspec.dart';
 class Config {
   Config._({required this.pubspec});
 
-  late final Pubspec pubspec;
+  final Pubspec pubspec;
 
+  @Deprecated('Access from pubspec')
   FlutterGen get flutterGen => pubspec.flutterGen;
 
+  @Deprecated('Access from pubspec')
   Flutter get flutter => pubspec.flutter;
 }
 
@@ -34,6 +36,8 @@ Future<Config> loadPubspecConfig(File pubspecFile) async {
 }
 
 const _defaultConfig = '''
+name: $invalidStringValue
+
 flutter_gen:
   output: lib/gen/
   # deprecated key

--- a/packages/core/lib/settings/pubspec.dart
+++ b/packages/core/lib/settings/pubspec.dart
@@ -4,9 +4,18 @@ part 'pubspec.g.dart';
 
 /// Edit this file, then run `make generate-config-model`
 
+const invalidStringValue = 'FLUTTER_GEN_INVALID';
+
 @JsonSerializable()
 class Pubspec {
-  Pubspec({required this.flutterGen, required this.flutter});
+  Pubspec({
+    required this.packageName,
+    required this.flutterGen,
+    required this.flutter,
+  });
+
+  @JsonKey(name: 'name', required: true)
+  final String packageName;
 
   @JsonKey(name: 'flutter_gen', required: true)
   final FlutterGen flutterGen;

--- a/packages/core/lib/settings/pubspec.g.dart
+++ b/packages/core/lib/settings/pubspec.g.dart
@@ -8,15 +8,16 @@ part of 'pubspec.dart';
 
 Pubspec _$PubspecFromJson(Map json) {
   return $checkedNew('Pubspec', json, () {
-    $checkKeys(json, requiredKeys: const ['flutter_gen', 'flutter']);
+    $checkKeys(json, requiredKeys: const ['name', 'flutter_gen', 'flutter']);
     final val = Pubspec(
+      packageName: $checkedConvert(json, 'name', (v) => v as String),
       flutterGen: $checkedConvert(
           json, 'flutter_gen', (v) => FlutterGen.fromJson(v as Map)),
       flutter:
           $checkedConvert(json, 'flutter', (v) => Flutter.fromJson(v as Map)),
     );
     return val;
-  }, fieldKeyMap: const {'flutterGen': 'flutter_gen'});
+  }, fieldKeyMap: const {'packageName': 'name', 'flutterGen': 'flutter_gen'});
 }
 
 Flutter _$FlutterFromJson(Map json) {

--- a/packages/core/test/assets_gen_integrations_test.dart
+++ b/packages/core/test/assets_gen_integrations_test.dart
@@ -30,8 +30,8 @@ void main() {
 
       expectedAssetsGen(pubspec, generated, fact);
 
-      final integration =
-          SvgIntegration(nullSafety: config.flutterGen.nullSafety);
+      final integration = SvgIntegration('package_name',
+          nullSafety: config.flutterGen.nullSafety);
       expect(integration.className, 'SvgGenImage');
       expect(integration.classInstantiate('assets/path'),
           'SvgGenImage\(\'assets/path\'\)');

--- a/packages/core/test/assets_gen_test.dart
+++ b/packages/core/test/assets_gen_test.dart
@@ -71,7 +71,7 @@ void main() {
 
       expect(() {
         return generateAssets(
-            pubspec, formatter, config.flutterGen, config.flutter.assets);
+            AssetsGenConfig.fromConfig(pubspec, config), formatter);
       }, throwsA(isA<InvalidSettingsException>()));
     });
   });

--- a/packages/core/test/gen_test_helper.dart
+++ b/packages/core/test/gen_test_helper.dart
@@ -23,8 +23,7 @@ void expectedAssetsGen(String pubspec, String generated, String fact) async {
       DartFormatter(pageWidth: config.flutterGen.lineLength, lineEnding: '\n');
 
   final actual = generateAssets(
-      pubspecFile, formatter, config.flutterGen, config.flutter.assets,
-      nullSafety: config.flutterGen.nullSafety);
+      AssetsGenConfig.fromConfig(pubspecFile, config), formatter);
   final expected = File(fact).readAsStringSync().replaceAll('\r\n', '\n');
 
   expect(

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -80,6 +80,8 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
@@ -91,7 +93,7 @@ class Assets {
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({
@@ -149,7 +151,7 @@ class SvgGenImage {
     Key? key,
     bool matchTextDirection = false,
     AssetBundle? bundle,
-    String? package,
+    String? package = 'test',
     double? width,
     double? height,
     BoxFit fit = BoxFit.contain,

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -80,8 +80,6 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();

--- a/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
@@ -8,6 +8,8 @@ import 'package:flutter/widgets.dart';
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const AssetGenImage imagesChip1 =
       AssetGenImage('assets/images/chip1.jpg');
   static const AssetGenImage imagesChip2 =
@@ -33,7 +35,7 @@ class Assets {
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({

--- a/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
@@ -8,8 +8,6 @@ import 'package:flutter/widgets.dart';
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const AssetGenImage imagesChip1 =
       AssetGenImage('assets/images/chip1.jpg');
   static const AssetGenImage imagesChip2 =

--- a/packages/core/test_resources/actual_data/assets_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_disable_null_safety.gen.dart
@@ -81,8 +81,6 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();

--- a/packages/core/test_resources/actual_data/assets_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_disable_null_safety.gen.dart
@@ -81,6 +81,8 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
@@ -92,7 +94,7 @@ class Assets {
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({
@@ -150,7 +152,7 @@ class SvgGenImage {
     Key key,
     bool matchTextDirection = false,
     AssetBundle bundle,
-    String package,
+    String package = 'test',
     double width,
     double height,
     BoxFit fit = BoxFit.contain,

--- a/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
@@ -16,13 +16,15 @@ class $AssetsFlareGen {
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const $AssetsFlareGen flare = $AssetsFlareGen();
 }
 
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({

--- a/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
@@ -16,8 +16,6 @@ class $AssetsFlareGen {
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const $AssetsFlareGen flare = $AssetsFlareGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
@@ -12,8 +12,6 @@ class $AssetsUnknownGen {
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
@@ -12,13 +12,15 @@ class $AssetsUnknownGen {
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }
 
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({

--- a/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
@@ -57,8 +57,6 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
   static const $PicturesGen pictures = $PicturesGen();

--- a/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
@@ -57,6 +57,8 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
   static const $PicturesGen pictures = $PicturesGen();
@@ -65,7 +67,7 @@ class Assets {
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({

--- a/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
@@ -8,8 +8,6 @@ import 'package:flutter/widgets.dart';
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const AssetGenImage images_chip1 =
       AssetGenImage('assets/images/chip1.jpg');
   static const AssetGenImage images_chip2 =

--- a/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
@@ -8,6 +8,8 @@ import 'package:flutter/widgets.dart';
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const AssetGenImage images_chip1 =
       AssetGenImage('assets/images/chip1.jpg');
   static const AssetGenImage images_chip2 =
@@ -33,7 +35,7 @@ class Assets {
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -23,13 +23,15 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({
@@ -87,7 +89,7 @@ class SvgGenImage {
     Key? key,
     bool matchTextDirection = false,
     AssetBundle? bundle,
-    String? package,
+    String? package = 'test',
     double? width,
     double? height,
     BoxFit fit = BoxFit.contain,

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -23,8 +23,6 @@ class $AssetsImagesIconsGen {
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
@@ -14,13 +14,15 @@ class $AssetsUnknownGen {
 class Assets {
   Assets._();
 
+  static const package = 'test';
+
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }
 
 class AssetGenImage extends AssetImage {
   const AssetGenImage(String assetName)
       : _assetName = assetName,
-        super(assetName);
+        super(assetName, package: 'test');
   final String _assetName;
 
   Image image({

--- a/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
@@ -14,8 +14,6 @@ class $AssetsUnknownGen {
 class Assets {
   Assets._();
 
-  static const package = 'test';
-
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }
 

--- a/packages/runner/pubspec.lock
+++ b/packages/runner/pubspec.lock
@@ -158,9 +158,9 @@ packages:
   flutter_gen_core:
     dependency: "direct main"
     description:
-      name: flutter_gen_core
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../core"
+      relative: true
+    source: path
     version: "3.0.2"
   glob:
     dependency: transitive

--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -20,3 +20,7 @@ dependencies:
 dev_dependencies:
   effective_dart: '>=1.3.0 <2.0.0'
   build_test: '>=1.3.0 <3.0.0'
+
+dependency_overrides:
+  flutter_gen_core:
+    path: ../core


### PR DESCRIPTION
### What does this change?
Fix: #50 

Set `package` argument for `AssetGenImage` and `SvgGenImage`

TODO:
Add package to flareActor after https://github.com/2d-inc/Flare-Flutter/issues/171 resolved

```dart

// AssetGenImage:
  const AssetGenImage(String assetName)
      : _assetName = assetName,
        super(assetName, package: 'example');

// SvgGenImage:
  SvgPicture svg({
    String? package = 'example',
    ...
  })
```

### What is the value of this and can you measure success?

CI Pass