### PR TITLE
fix: use normal header in no null safety mode

### DIFF
--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -97,12 +97,7 @@ String generateAssets(
 
   final buffer = StringBuffer();
 
-  // TODO: Until null safety generalizes
-  if (config.flutterGen.nullSafety) {
-    buffer.writeln(header);
-  } else {
-    buffer.writeln(headerWithNoNullSafety);
-  }
+  buffer.writeln(header);
   buffer.writeln(importsBuffer.toString());
   buffer.writeln(classesBuffer.toString());
   return formatter.format(buffer.toString());

--- a/packages/core/lib/generators/generator_helper.dart
+++ b/packages/core/lib/generators/generator_helper.dart
@@ -7,17 +7,6 @@ String get header {
 ''';
 }
 
-/// TODO: Until null safety generalizes
-String get headerWithNoNullSafety {
-  return '''// @dart = 2.10
-/// GENERATED CODE - DO NOT MODIFY BY HAND
-/// *****************************************************
-///  FlutterGen
-/// *****************************************************
-
-''';
-}
-
 String import(String package) => 'import \'$package\';';
 
 // Replace to Posix style for Windows separator.

--- a/packages/core/test/assets_gen_test.dart
+++ b/packages/core/test/assets_gen_test.dart
@@ -85,8 +85,9 @@ void main() {
       expectedAssetsGen(pubspec, generated, fact);
     });
 
-    test('Assets with package parameter enabled', () async {
-      final pubspec = 'test_resources/pubspec_assets_package_parameter.yaml';
+    test('Assets with package parameter enabled disable null safety', () async {
+      final pubspec =
+          'test_resources/pubspec_assets_package_parameter_disable_null_safety.yaml';
       final fact =
           'test_resources/actual_data/assets_package_parameter_disable_null_safety.gen.dart';
       final generated =

--- a/packages/core/test_resources/actual_data/assets_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_disable_null_safety.gen.dart
@@ -1,4 +1,3 @@
-// @dart = 2.10
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen


### PR DESCRIPTION
### What does this change?
resolve #108

We can both generate null-safety and no-null-safety codes.
So there is no need to generate the dart version comment.

### What is the value of this and can you measure success?
CI Pass
