### PR TITLE
refactor: add directives_ordering for analysis

### DIFF
--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,10 +1,5 @@
 include: package:effective_dart/analysis_options.yaml
 
-analyzer:
-  exclude:
-    - '**/*.g.dart'
-    - 'test_resources/**'
-
 linter:
   rules:
     public_member_api_docs: false

--- a/example/lib/gen/assets.gen.dart
+++ b/example/lib/gen/assets.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter/services.dart';

--- a/example/lib/gen/colors.gen.dart
+++ b/example/lib/gen/colors.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 

--- a/example/lib/gen/fonts.gen.dart
+++ b/example/lib/gen/fonts.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 class FontFamily {
   FontFamily._();
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,9 @@
-import 'package:example/gen/assets.gen.dart';
-import 'package:example/gen/colors.gen.dart';
-import 'package:example/gen/fonts.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+
+import 'gen/assets.gen.dart';
+import 'gen/colors.gen.dart';
+import 'gen/fonts.gen.dart';
 
 void main() {
   runApp(MaterialApp(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -176,6 +176,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.1"
+  effective_dart:
+    dependency: "direct dev"
+    description:
+      name: effective_dart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.2"
   fake_async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,6 +23,8 @@ dev_dependencies:
   flutter_gen_runner:
     path: ../packages/runner
 
+  effective_dart: '>=1.3.1 <2.0.0'
+
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
   line_length: 80   # Optional (default: 80)

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -88,6 +88,7 @@ String generateAssets(
   final buffer = StringBuffer();
 
   buffer.writeln(header);
+  buffer.writeln(ignoreAnalysis);
   buffer.writeln(importsBuffer.toString());
   buffer.writeln(classesBuffer.toString());
   return formatter.format(buffer.toString());

--- a/packages/core/lib/generators/colors_generator.dart
+++ b/packages/core/lib/generators/colors_generator.dart
@@ -24,6 +24,7 @@ String generateColors(
 
   final buffer = StringBuffer();
   buffer.writeln(header);
+  buffer.writeln(ignoreAnalysis);
   buffer.writeln("import 'package:flutter/painting.dart';");
   buffer.writeln("import 'package:flutter/material.dart';");
   buffer.writeln();

--- a/packages/core/lib/generators/fonts_generator.dart
+++ b/packages/core/lib/generators/fonts_generator.dart
@@ -17,6 +17,7 @@ String generateFonts(
 
   final buffer = StringBuffer();
   buffer.writeln(header);
+  buffer.writeln(ignoreAnalysis);
   buffer.writeln('class FontFamily {');
   buffer.writeln('  FontFamily._();');
   buffer.writeln();

--- a/packages/core/lib/generators/generator_helper.dart
+++ b/packages/core/lib/generators/generator_helper.dart
@@ -7,6 +7,12 @@ String get header {
 ''';
 }
 
+String get ignoreAnalysis {
+  return '''// ignore_for_file: directives_ordering
+  
+''';
+}
+
 String import(String package) => 'import \'$package\';';
 
 // Replace to Posix style for Windows separator.

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter/services.dart';

--- a/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 
 class Assets {

--- a/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 import 'package:flare_flutter/flare_actor.dart';
 import 'package:flare_flutter/flare_controller.dart';

--- a/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 
 class $AssetsUnknownGen {

--- a/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 
 class $PicturesGen {

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter/services.dart';

--- a/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 
 class Assets {

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter/services.dart';

--- a/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/widgets.dart';
 
 class $AssetsUnknownGen {

--- a/packages/core/test_resources/actual_data/colors.gen.dart
+++ b/packages/core/test_resources/actual_data/colors.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 

--- a/packages/core/test_resources/actual_data/fonts.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+// ignore_for_file: directives_ordering
+
 class FontFamily {
   FontFamily._();
 


### PR DESCRIPTION
### What does this change?

- Add `directives_ordering` each `*.gen.dart` for not using `analysis_options.yaml`.

