### PR TITLE
Fix: _Statement.toDartDocString generates different strings on Windows and Ubuntu.

### DIFF
--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -425,7 +425,7 @@ class _Statement {
   final bool isConstConstructor;
   final bool needDartDoc;
 
-  String toDartDocString() => '/// File path: ${filePath.replaceAll('\\', '/')}';
+  String toDartDocString() => '/// File path: ${posixStyle(filePath)}';
 
   String toGetterString() =>
       '$type get $name => ${isConstConstructor ? 'const' : ''} $value;';

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -425,7 +425,7 @@ class _Statement {
   final bool isConstConstructor;
   final bool needDartDoc;
 
-  String toDartDocString() => '/// File path: $filePath';
+  String toDartDocString() => '/// File path: ${filePath.replaceAll('\\', '/')}';
 
   String toGetterString() =>
       '$type get $name => ${isConstConstructor ? 'const' : ''} $value;';


### PR DESCRIPTION
What's wrong:
_Statement.toDartDocString generates different strings on Windows and Ubuntu.
It causes changes in git if file was initially generated on Ubuntu, then checked out on Windows.

Ubuntu:    /// File path: assets/images/state/empty_state_new_space_black.svg
Windows: /// File path: assets\images\state\empty_state_new_space_black.svg

Fix: Write Linux-style path on Windows too.

