### PR TITLE
chore: release v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.1.1
+
+**Bug fix**
+- [#156](https://github.com/FlutterGen/flutter_gen/pull/156) The Dartdocs generate different strings on Windows and Ubuntu.
+
+**Features**
+- [#157](https://github.com/FlutterGen/flutter_gen/pull/157) The supported version of json_serializable `>=5.0.0 <6.0.0` -> `>=5.0.0 <7.0.0`.
+
 ## 4.1.0
 
 **Feature**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -215,14 +215,14 @@ packages:
       path: "../packages/core"
       relative: true
     source: path
-    version: "4.1.0"
+    version: "4.1.1"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       path: "../packages/runner"
       relative: true
     source: path
-    version: "4.1.0"
+    version: "4.1.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -236,7 +236,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.22.0"
+    version: "0.23.0+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/packages/command/pubspec.lock
+++ b/packages/command/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       path: "../core"
       relative: true
     source: path
-    version: "4.1.0"
+    version: "4.1.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/command/pubspec.yaml
+++ b/packages/command/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen
@@ -14,7 +14,7 @@ executables:
   fluttergen: flutter_gen_command
 
 dependencies:
-  flutter_gen_core: ^4.1.0
+  flutter_gen_core: ^4.1.1
   args: '>=2.0.0 <3.0.0'
 
 dev_dependencies:

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_core
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen

--- a/packages/runner/pubspec.lock
+++ b/packages/runner/pubspec.lock
@@ -161,7 +161,7 @@ packages:
       path: "../core"
       relative: true
     source: path
-    version: "4.1.0"
+    version: "4.1.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_runner
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  flutter_gen_core: ^4.1.0
+  flutter_gen_core: ^4.1.1
   build: '>=2.0.0 <3.0.0'
 
 dev_dependencies:


### PR DESCRIPTION
### What does this change?

**Bug fix**
- [#156](https://github.com/FlutterGen/flutter_gen/pull/156) The Dartdocs generate different strings on Windows and Ubuntu.

**Features**
- [#157](https://github.com/FlutterGen/flutter_gen/pull/157) The supported version of json_serializable `>=5.0.0 <6.0.0` -> `>=5.0.0 <7.0.0`.