### PR TITLE
expose theme parameter of SvgPicture

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ class SvgGenImage {
     String semanticsLabel,
     bool excludeFromSemantics = false,
     Clip clipBehavior = Clip.hardEdge,
+    SvgTheme? theme,
   }) {
     return SvgPicture.asset(
       _assetName,
@@ -453,6 +454,7 @@ class SvgGenImage {
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
       clipBehavior: clipBehavior,
+      theme: theme,
     );
   }
 

--- a/packages/core/lib/generators/integrations/svg_integration.dart
+++ b/packages/core/lib/generators/integrations/svg_integration.dart
@@ -40,6 +40,7 @@ class SvgIntegration extends Integration {
     String? semanticsLabel,
     bool excludeFromSemantics = false,
     Clip clipBehavior = Clip.hardEdge,
+    SvgTheme? theme,
   }) {
     return SvgPicture.asset(
       _assetName,
@@ -58,6 +59,7 @@ class SvgIntegration extends Integration {
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
       clipBehavior: clipBehavior,
+      theme: theme,
     );
   }
 

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -186,6 +186,7 @@ class SvgGenImage {
     String? semanticsLabel,
     bool excludeFromSemantics = false,
     Clip clipBehavior = Clip.hardEdge,
+    SvgTheme? theme,
   }) {
     return SvgPicture.asset(
       _assetName,
@@ -204,6 +205,7 @@ class SvgGenImage {
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
       clipBehavior: clipBehavior,
+      theme: theme,
     );
   }
 

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -112,6 +112,7 @@ class SvgGenImage {
     String? semanticsLabel,
     bool excludeFromSemantics = false,
     Clip clipBehavior = Clip.hardEdge,
+    SvgTheme? theme,
   }) {
     return SvgPicture.asset(
       _assetName,
@@ -130,6 +131,7 @@ class SvgGenImage {
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
       clipBehavior: clipBehavior,
+      theme: theme,
     );
   }
 

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -103,6 +103,7 @@ class SvgGenImage {
     String? semanticsLabel,
     bool excludeFromSemantics = false,
     Clip clipBehavior = Clip.hardEdge,
+    SvgTheme? theme,
   }) {
     return SvgPicture.asset(
       _assetName,
@@ -121,6 +122,7 @@ class SvgGenImage {
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
       clipBehavior: clipBehavior,
+      theme: theme,
     );
   }
 


### PR DESCRIPTION
### What does this change?

- expose `theme` parameter of `SvgPicture`

This is useful to specify svg's `currentColor` property recently supported by `flutter_svg`.

[SvgTheme class](https://pub.dev/documentation/flutter_svg/latest/flutter_svg/SvgTheme-class.html)