### PR TITLE
Added 'gen_for_package:true/false' param to support asset generation for a package

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -42,6 +42,9 @@ flutter_gen:
   assets:
     enabled: true
     package_parameter_enabled: false
+    # generate assets for package
+    gen_for_package: false
+
     # Assets.imagesChip
     # style: camel-case
 

--- a/packages/core/lib/settings/config.dart
+++ b/packages/core/lib/settings/config.dart
@@ -44,6 +44,7 @@ flutter_gen:
   assets:
     enabled: true
     package_parameter_enabled: false
+    gen_for_package: false
     style: dot-delimiter
     
   fonts:

--- a/packages/core/lib/settings/pubspec.dart
+++ b/packages/core/lib/settings/pubspec.dart
@@ -105,6 +105,7 @@ class FlutterGenAssets {
     required this.enabled,
     required this.packageParameterEnabled,
     required this.style,
+    required this.genForPackage,
   }) {
     if (style != dotDelimiterStyle &&
         style != snakeCaseStyle &&
@@ -121,6 +122,9 @@ class FlutterGenAssets {
 
   @JsonKey(name: 'style', required: true)
   final String style;
+
+  @JsonKey(name: 'gen_for_package', required: true)
+  final bool genForPackage;
 
   bool get isDotDelimiterStyle => style == dotDelimiterStyle;
 

--- a/packages/core/lib/settings/pubspec.g.dart
+++ b/packages/core/lib/settings/pubspec.g.dart
@@ -117,18 +117,25 @@ FlutterGenAssets _$FlutterGenAssetsFromJson(Map json) => $checkedCreate(
       ($checkedConvert) {
         $checkKeys(
           json,
-          requiredKeys: const ['enabled', 'package_parameter_enabled', 'style'],
+          requiredKeys: const [
+            'enabled',
+            'package_parameter_enabled',
+            'style',
+            'gen_for_package'
+          ],
         );
         final val = FlutterGenAssets(
           enabled: $checkedConvert('enabled', (v) => v as bool),
           packageParameterEnabled:
               $checkedConvert('package_parameter_enabled', (v) => v as bool),
           style: $checkedConvert('style', (v) => v as String),
+          genForPackage: $checkedConvert('gen_for_package', (v) => v as bool),
         );
         return val;
       },
       fieldKeyMap: const {
-        'packageParameterEnabled': 'package_parameter_enabled'
+        'packageParameterEnabled': 'package_parameter_enabled',
+        'genForPackage': 'gen_for_package'
       },
     );
 


### PR DESCRIPTION
### Why fix is required?
Currently if we use **fluttergen** then the asset path generated won't work for packages as it expects assets path from `packages/<package_name>/<asset_path>`

### What is changed/added?
Added flutter package support:
- By added `gen_for_package:true` to the fluttergen config it will generate assets with path that can be resolved in a package.

