### PR TITLE
Added coverage:ignore-file comment in generated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.6+1
+**Feature**
+- Added `coverage:ignore-file` comment in generated files to ignore generated files from code coverage.
+
 ## 4.1.6
 
 **Feature**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -212,16 +212,16 @@ packages:
   flutter_gen_core:
     dependency: transitive
     description:
-      path: "../packages/core"
-      relative: true
-    source: path
+      name: flutter_gen_core
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "4.1.6"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
-      path: "../packages/runner"
-      relative: true
-    source: path
+      name: flutter_gen_runner
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "4.1.6"
   flutter_lints:
     dependency: "direct dev"
@@ -347,6 +347,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -505,7 +512,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   time:
     dependency: transitive
     description:

--- a/packages/command/pubspec.lock
+++ b/packages/command/pubspec.lock
@@ -102,9 +102,9 @@ packages:
   flutter_gen_core:
     dependency: "direct main"
     description:
-      path: "../core"
-      relative: true
-    source: path
+      name: flutter_gen_core
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "4.1.6"
   flutter_lints:
     dependency: "direct dev"

--- a/packages/command/pubspec.yaml
+++ b/packages/command/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.1.6
+version: 4.1.6+1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen

--- a/packages/core/lib/generators/generator_helper.dart
+++ b/packages/core/lib/generators/generator_helper.dart
@@ -1,5 +1,6 @@
 String get header {
-  return '''/// GENERATED CODE - DO NOT MODIFY BY HAND
+  return '''// coverage:ignore-file
+/// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
 /// *****************************************************

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_core
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.1.6
+version: 4.1.6+1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen

--- a/packages/runner/pubspec.lock
+++ b/packages/runner/pubspec.lock
@@ -158,9 +158,9 @@ packages:
   flutter_gen_core:
     dependency: "direct main"
     description:
-      path: "../core"
-      relative: true
-    source: path
+      name: flutter_gen_core
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "4.1.6"
   flutter_lints:
     dependency: "direct dev"

--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_runner
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.1.6
+version: 4.1.6+1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen


### PR DESCRIPTION
### Why fix is required?
Currently all generated files with `flutter_gen` are included in the coverage report after run `flutter test --coverage`. With this PR the all generated files will include the `coverage:ignore-file` comment.

