### PR TITLE
Fix linter warn: `use_super_parameters`

### DIFF
--- a/packages/core/lib/generators/generator_helper.dart
+++ b/packages/core/lib/generators/generator_helper.dart
@@ -8,7 +8,7 @@ String get header {
 }
 
 String get ignoreAnalysis {
-  return '''// ignore_for_file: directives_ordering,unnecessary_import
+  return '''// ignore_for_file: directives_ordering, unnecessary_import, use_super_parameters
   
 ''';
 }


### PR DESCRIPTION
Closes #222