### PR TITLE
added coverage ignore comment on header

### DIFF
--- a/packages/core/lib/generators/generator_helper.dart
+++ b/packages/core/lib/generators/generator_helper.dart
@@ -1,5 +1,6 @@
 String get header {
-  return '''/// GENERATED CODE - DO NOT MODIFY BY HAND
+  return '''// coverage:ignore-file
+/// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
 /// *****************************************************


### PR DESCRIPTION
### Why fix is required?
Currently all generated files with `flutter_gen` are included in the coverage report after run `flutter test --coverage`. With this PR the all generated files will include the `coverage:ignore-file` comment.

