### PR TITLE
chore: bump up to v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.2.1
+
+**Bug fix**
+- [#236](https://github.com/FlutterGen/flutter_gen/issues/236) The crypto package 3.0.2 conflict in flutter_gen_runner 4.2.0 with integration_test.
+
 ## 4.2.0
 
 **Feature**

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -107,7 +107,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   build_runner: ^2.1.11
-  flutter_gen_runner: ^4.2.0
+  flutter_gen_runner: ^4.2.1
 
   flutter_lints: ^2.0.1
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
   # Dependency check
   collection: ^1.16.0
-  crypto: ^3.0.2
+  crypto: ^3.0.1
   glob: ^2.0.2
   
   firebase_analytics: 9.1.8
@@ -103,6 +103,8 @@ dependencies:
 
 dev_dependencies:
   flutter_test:
+    sdk: flutter
+  integration_test:
     sdk: flutter
   build_runner: ^2.1.11
   flutter_gen_runner: ^4.2.0

--- a/example_resources/pubspec.yaml
+++ b/example_resources/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.11
-  flutter_gen_runner: ^4.2.0
+  flutter_gen_runner: ^4.2.1
 
 flutter_gen:
   output: lib/gen/

--- a/packages/command/pubspec.yaml
+++ b/packages/command/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.2.0
+version: 4.2.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen
@@ -14,7 +14,7 @@ executables:
   fluttergen: flutter_gen_command
 
 dependencies:
-  flutter_gen_core: ^4.2.0
+  flutter_gen_core: ^4.2.1
   args: '>=2.0.0 <3.0.0'
 
 dev_dependencies:

--- a/packages/command/pubspec.yaml
+++ b/packages/command/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
   args: '>=2.0.0 <3.0.0'
 
 dev_dependencies:
-  flutter_lints: ^2.0.1
+  flutter_lints: '>=2.0.1 <3.0.0'

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
 
 dev_dependencies:
   test: '>=1.16.0 <2.0.0'
-  flutter_lints: ^2.0.1
+  flutter_lints: '>=2.0.1 <3.0.0'
   build_runner: '>=2.0.0 <3.0.0'
   json_serializable: '>=6.0.0 <7.0.0'
   version_gen: '>=1.0.1 <2.0.0'

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_core
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.2.0
+version: 4.2.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen

--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_runner
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 4.2.0
+version: 4.2.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  flutter_gen_core: ^4.2.0
+  flutter_gen_core: ^4.2.1
   build: '>=2.0.0 <3.0.0'
   collection: '>=1.15.0 <2.0.0'
   crypto: '>=3.0.0 <4.0.0'

--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -13,9 +13,9 @@ environment:
 dependencies:
   flutter_gen_core: ^4.2.0
   build: '>=2.0.0 <3.0.0'
-  collection: ^1.16.0
-  crypto: ^3.0.2
-  glob: ^2.0.2
+  collection: '>=1.15.0 <2.0.0'
+  crypto: '>=3.0.0 <4.0.0'
+  glob: '>=2.0.0 <3.0.0'
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
   glob: '>=2.0.0 <3.0.0'
 
 dev_dependencies:
-  flutter_lints: ^2.0.1
+  flutter_lints: '>=2.0.1 <3.0.0'
   build_test: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
### What does this change?


**Bug fix**
- [#236](https://github.com/FlutterGen/flutter_gen/issues/236) The crypto package 3.0.2 conflict in flutter_gen_runner 4.2.0 with integration_test.