### PR TITLE
Added values list to generated classes

### DIFF
--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -363,7 +363,7 @@ class $className {
   $statementsBlock
 
   /// List of all assets
-  List<$commonType> get values => [$names];
+  List<$commonType> get values => [$names,];
 }
 ''';
 }

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -333,6 +333,16 @@ class Assets {
 ''';
 }
 
+/// tries to determine a common type or returns 'dynamic'
+String _typeOfMultipleStatements(List<_Statement> statements) {
+  String? type;
+  for (var statement in statements) {
+    type ??= statement.type;
+    if (statement.type != type) return 'dynamic';
+  }
+  return type ?? 'dynamic';
+}
+
 String _directoryClassGenDefinition(
   String className,
   List<_Statement> statements,
@@ -344,11 +354,16 @@ String _directoryClassGenDefinition(
           '''
           : statement.toGetterString())
       .join('\n');
+  final commonType = _typeOfMultipleStatements(statements);
+  final names = statements.map((statement) => statement.name).join(', ');
   return '''
 class $className {
   const $className();
   
   $statementsBlock
+
+  /// List of all assets
+  List<$commonType> get values => [$names];
 }
 ''';
 }


### PR DESCRIPTION
### What does this change?

This PR implements a feature requested in #186.
It adds `values` getter at the end of generated classes for directories with the list of all statement' names.

### Possible problem:
Name collision of `values` with an existing asset. Feel free to suggest some less generic name so I'll rename it (or simply edit it yourself). I just don't have any ideas about naming conventions for a predetermined field for this project. 

### Possible improvement: 
Make this list optional with some flag.