### PR TITLE
refactor: moved style and package_parameter_enabled to under assets.outputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,15 +243,14 @@ final json = await rootBundle.loadString(Assets.json.fruits);
 # pubspec.yaml
 flutter_gen:
   assets:
-    outputs:
-      # Assets.imagesChip
-      # style: camel-case
+    # Assets.imagesChip
+    # style: camel-case
 
-      # Assets.images_chip
-      # style: snake-case
+    # Assets.images_chip
+    # style: snake-case
 
-      # Assets.images.chip (default style)
-      # style: dot-delimiter
+    # Assets.images.chip (default style)
+    # style: dot-delimiter
 
 flutter:
   assets:

--- a/README.md
+++ b/README.md
@@ -730,19 +730,19 @@ flutter_gen:
     # Optional
     enabled: true
     # Optional
-    # Set to true if you want this package to be a package dependency
-    # See: https://flutter.dev/docs/development/ui/assets-and-images#from-packages
-    package_parameter_enabled: false
-    # Optional
-    # Avaliable values:
-    # - camel-case
-    # - snake-case
-    # - dot-delimiter
-    style: dot-delimiter
-    # Optional
     outputs:
       # Default is Assets
       class_name: MyAssets
+      # Optional
+      # Set to true if you want this package to be a package dependency
+      # See: https://flutter.dev/docs/development/ui/assets-and-images#from-packages
+      package_parameter_enabled: false
+      # Optional
+      # Avaliable values:
+      # - camel-case
+      # - snake-case
+      # - dot-delimiter
+      style: dot-delimiter
     
   fonts:
     # Optional

--- a/README.md
+++ b/README.md
@@ -243,14 +243,15 @@ final json = await rootBundle.loadString(Assets.json.fruits);
 # pubspec.yaml
 flutter_gen:
   assets:
-    # Assets.imagesChip
-    # style: camel-case
+    outputs:
+      # Assets.imagesChip
+      # style: camel-case
 
-    # Assets.images_chip
-    # style: snake-case
+      # Assets.images_chip
+      # style: snake-case
 
-    # Assets.images.chip (default style)
-    # style: dot-delimiter
+      # Assets.images.chip (default style)
+      # style: dot-delimiter
 
 flutter:
   assets:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -123,10 +123,6 @@ flutter_gen:
   assets:
     enabled: true
 
-    # Moved under outputs:
-    # package_parameter_enabled: false
-    # style: snake-case
-
     outputs:
       class_name: MyAssets
       package_parameter_enabled: false

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -123,12 +123,13 @@ flutter_gen:
   assets:
     enabled: true
 
-    package_parameter_enabled: false
-    style: snake-case
+    # Moved under outputs:
+    # package_parameter_enabled: false
+    # style: snake-case
 
     outputs:
       class_name: MyAssets
-      # package_parameter_enabled: false
+      package_parameter_enabled: false
       # Assets.imagesChip
       # style: camel-case
 
@@ -136,7 +137,7 @@ flutter_gen:
       # style: snake-case
 
       # Assets.images.chip (default style)
-      # style: snake-case
+      style: dot-delimiter
 
     exclude:
       - assets/images/chip3/chip3.jpg

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   collection: ^1.16.0
   crypto: ^3.0.1
   glob: ^2.0.2
-  
+
   firebase_analytics: 9.1.8
   firebase_core: 1.14.1
   firebase_auth: 3.3.18
@@ -122,18 +122,21 @@ flutter_gen:
 
   assets:
     enabled: true
+
     package_parameter_enabled: false
-    # Assets.imagesChip
-    # style: camel-case
-
-    # Assets.images_chip
-    # style: snake-case
-
-    # Assets.images.chip (default style)
-    # style: dot-delimiter
+    style: snake-case
 
     outputs:
       class_name: MyAssets
+      # package_parameter_enabled: false
+      # Assets.imagesChip
+      # style: camel-case
+
+      # Assets.images_chip
+      # style: snake-case
+
+      # Assets.images.chip (default style)
+      # style: snake-case
 
     exclude:
       - assets/images/chip3/chip3.jpg

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -70,10 +70,59 @@ String generateAssets(
 
   // TODO: This code will be removed.
   // ignore: deprecated_member_use_from_same_package
-  if (config.flutterGen.assets.style != null) {
+  final deprecatedStyle = config.flutterGen.assets.style != null;
+  final deprecatedPackageParam =
+      // ignore: deprecated_member_use_from_same_package
+      config.flutterGen.assets.packageParameterEnabled != null;
+  if (deprecatedStyle || deprecatedPackageParam) {
+    stderr.writeln('''
+                                                                                        
+                ░░░░                                                                    
+                                                                                        
+                                            ██                                          
+                                          ██░░██                                        
+  ░░          ░░                        ██░░░░░░██                            ░░░░      
+                                      ██░░░░░░░░░░██                                    
+                                      ██░░░░░░░░░░██                                    
+                                    ██░░░░░░░░░░░░░░██                                  
+                                  ██░░░░░░██████░░░░░░██                                
+                                  ██░░░░░░██████░░░░░░██                                
+                                ██░░░░░░░░██████░░░░░░░░██                              
+                                ██░░░░░░░░██████░░░░░░░░██                              
+                              ██░░░░░░░░░░██████░░░░░░░░░░██                            
+                            ██░░░░░░░░░░░░██████░░░░░░░░░░░░██                          
+                            ██░░░░░░░░░░░░██████░░░░░░░░░░░░██                          
+                          ██░░░░░░░░░░░░░░██████░░░░░░░░░░░░░░██                        
+                          ██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██                        
+                        ██░░░░░░░░░░░░░░░░██████░░░░░░░░░░░░░░░░██                      
+                        ██░░░░░░░░░░░░░░░░██████░░░░░░░░░░░░░░░░██                      
+                      ██░░░░░░░░░░░░░░░░░░██████░░░░░░░░░░░░░░░░░░██                    
+        ░░            ██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██                    
+                        ██████████████████████████████████████████                      
+                                                                                        
+                                                                                        
+                  ░░''');
+  }
+  if (deprecatedStyle && deprecatedPackageParam) {
+    stderr.writeln('''
+    ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+    │ ⚠️  Warning                                                                                     │
+    │   The `style` and `package_parameter_enabled` property moved from asset to under asset.output. │
+    │   It should be changed in the following pubspec.yaml.                                          │
+    │   https://github.com/FlutterGen/flutter_gen/pull/294                                           │
+    │                                                                                                │
+    │ [pubspec.yaml]                                                                                 │
+    │                                                                                                │
+    │  fluttergen:                                                                                   │
+    │    assets:                                                                                     │
+    │      outputs:                                                                                  │
+    │        style: snake-case                                                                       │
+    │        package_parameter_enabled: true                                                         │
+    └────────────────────────────────────────────────────────────────────────────────────────────────┘''');
+  } else if (deprecatedStyle) {
     stderr.writeln('''
     ┌───────────────────────────────────────────────────────────────────────┐
-    │ Warning:                                                              │
+    │ ⚠️  Warning                                                            │
     │   The `style` property moved from asset to under asset.output.        │
     │   It should be changed in the following ways                          │
     │   https://github.com/FlutterGen/flutter_gen/pull/294                  │
@@ -85,14 +134,10 @@ String generateAssets(
     │      outputs:                                                         │
     │        style: snake-case                                              │
     └───────────────────────────────────────────────────────────────────────┘''');
-  }
-
-  // TODO: This code will be removed.
-  // ignore: deprecated_member_use_from_same_package
-  if (config.flutterGen.assets.packageParameterEnabled != null) {
+  } else if (deprecatedPackageParam) {
     stderr.writeln('''
     ┌────────────────────────────────────────────────────────────────────────────────────────┐
-    │ Warning:                                                                               │
+    │ ⚠️  Warning                                                                             │
     │   The `package_parameter_enabled` property moved from asset to under asset.output.     │
     │   It should be changed in the following pubspec.yaml.                                  │
     │   https://github.com/FlutterGen/flutter_gen/pull/294                                   │

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -75,6 +75,7 @@ String generateAssets(
     │ Warning:                                                                   │
     │   the `style` property moved from asset to under asset.output.             │
     │   it should be changed in the following ways                               │
+    │   https://github.com/FlutterGen/flutter_gen/pull/294                       │
     │                                                                            │
     │ [pubspec.yaml]                                                             │
     │                                                                            │
@@ -91,6 +92,7 @@ String generateAssets(
     │ Warning:                                                                                  │
     │   The `package_parameter_enabled` property moved from asset to under asset.output.        │
     │   It should be changed in the following pubspec.yaml.                                     │
+    │   https://github.com/FlutterGen/flutter_gen/pull/294                                      │
     │                                                                                           │
     │ [pubspec.yaml]                                                                            │
     │                                                                                           │

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -46,7 +46,7 @@ class AssetsGenConfig {
   final List<Glob> exclude;
 
   String get packageParameterLiteral =>
-      flutterGen.assets.packageParameterEnabled ? _packageName : '';
+      flutterGen.assets.outputs.packageParameterEnabled ? _packageName : '';
 }
 
 String generateAssets(
@@ -68,11 +68,44 @@ String generateAssets(
     if (config.flutterGen.integrations.rive) RiveIntegration(),
   ];
 
-  if (config.flutterGen.assets.isDotDelimiterStyle) {
+  // ignore: deprecated_member_use_from_same_package
+  if (config.flutterGen.assets.style != null) {
+    stderr.writeln('''
+    ┌────────────────────────────────────────────────────────────────────────────┐
+    │ Warning:                                                                   │
+    │   the `style` property moved from asset to under asset.output.             │
+    │   it should be changed in the following ways                               │
+    │                                                                            │
+    │ [pubspec.yaml]                                                             │
+    │                                                                            │
+    │  fluttergen:                                                               │
+    │    assets:                                                                 │
+    │      outputs:                                                              │
+    │        style: snake-case                                                   │
+    └────────────────────────────────────────────────────────────────────────────┘''');
+  }
+  // ignore: deprecated_member_use_from_same_package
+  if (config.flutterGen.assets.packageParameterEnabled != null) {
+    stderr.writeln('''
+    ┌───────────────────────────────────────────────────────────────────────────────────────────┐
+    │ Warning:                                                                                  │
+    │   The `package_parameter_enabled` property moved from asset to under asset.output.        │
+    │   It should be changed in the following pubspec.yaml.                                     │
+    │                                                                                           │
+    │ [pubspec.yaml]                                                                            │
+    │                                                                                           │
+    │  fluttergen:                                                                              │
+    │    assets:                                                                                │
+    │      outputs:                                                                             │
+    │        package_parameter_enabled: true                                                    │
+    └───────────────────────────────────────────────────────────────────────────────────────────┘''');
+  }
+
+  if (config.flutterGen.assets.outputs.isDotDelimiterStyle) {
     classesBuffer.writeln(_dotDelimiterStyleDefinition(config, integrations));
-  } else if (config.flutterGen.assets.isSnakeCaseStyle) {
+  } else if (config.flutterGen.assets.outputs.isSnakeCaseStyle) {
     classesBuffer.writeln(_snakeCaseStyleDefinition(config, integrations));
-  } else if (config.flutterGen.assets.isCamelCaseStyle) {
+  } else if (config.flutterGen.assets.outputs.isCamelCaseStyle) {
     classesBuffer.writeln(_camelCaseStyleDefinition(config, integrations));
   } else {
     throw 'The value of "flutter_gen/assets/style." is incorrect.';

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -68,13 +68,14 @@ String generateAssets(
     if (config.flutterGen.integrations.rive) RiveIntegration(),
   ];
 
+  // TODO: Will delete this code after.
   // ignore: deprecated_member_use_from_same_package
   if (config.flutterGen.assets.style != null) {
     stderr.writeln('''
     ┌────────────────────────────────────────────────────────────────────────────┐
     │ Warning:                                                                   │
-    │   the `style` property moved from asset to under asset.output.             │
-    │   it should be changed in the following ways                               │
+    │   The `style` property moved from asset to under asset.output.             │
+    │   It should be changed in the following ways                               │
     │   https://github.com/FlutterGen/flutter_gen/pull/294                       │
     │                                                                            │
     │ [pubspec.yaml]                                                             │
@@ -85,6 +86,8 @@ String generateAssets(
     │        style: snake-case                                                   │
     └────────────────────────────────────────────────────────────────────────────┘''');
   }
+
+  // TODO: Will delete this code after.
   // ignore: deprecated_member_use_from_same_package
   if (config.flutterGen.assets.packageParameterEnabled != null) {
     stderr.writeln('''

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -68,42 +68,42 @@ String generateAssets(
     if (config.flutterGen.integrations.rive) RiveIntegration(),
   ];
 
-  // TODO: Will delete this code after.
+  // TODO: This code will be removed.
   // ignore: deprecated_member_use_from_same_package
   if (config.flutterGen.assets.style != null) {
     stderr.writeln('''
-    ┌────────────────────────────────────────────────────────────────────────────┐
-    │ Warning:                                                                   │
-    │   The `style` property moved from asset to under asset.output.             │
-    │   It should be changed in the following ways                               │
-    │   https://github.com/FlutterGen/flutter_gen/pull/294                       │
-    │                                                                            │
-    │ [pubspec.yaml]                                                             │
-    │                                                                            │
-    │  fluttergen:                                                               │
-    │    assets:                                                                 │
-    │      outputs:                                                              │
-    │        style: snake-case                                                   │
-    └────────────────────────────────────────────────────────────────────────────┘''');
+    ┌───────────────────────────────────────────────────────────────────────┐
+    │ Warning:                                                              │
+    │   The `style` property moved from asset to under asset.output.        │
+    │   It should be changed in the following ways                          │
+    │   https://github.com/FlutterGen/flutter_gen/pull/294                  │
+    │                                                                       │
+    │ [pubspec.yaml]                                                        │
+    │                                                                       │
+    │  fluttergen:                                                          │
+    │    assets:                                                            │
+    │      outputs:                                                         │
+    │        style: snake-case                                              │
+    └───────────────────────────────────────────────────────────────────────┘''');
   }
 
-  // TODO: Will delete this code after.
+  // TODO: This code will be removed.
   // ignore: deprecated_member_use_from_same_package
   if (config.flutterGen.assets.packageParameterEnabled != null) {
     stderr.writeln('''
-    ┌───────────────────────────────────────────────────────────────────────────────────────────┐
-    │ Warning:                                                                                  │
-    │   The `package_parameter_enabled` property moved from asset to under asset.output.        │
-    │   It should be changed in the following pubspec.yaml.                                     │
-    │   https://github.com/FlutterGen/flutter_gen/pull/294                                      │
-    │                                                                                           │
-    │ [pubspec.yaml]                                                                            │
-    │                                                                                           │
-    │  fluttergen:                                                                              │
-    │    assets:                                                                                │
-    │      outputs:                                                                             │
-    │        package_parameter_enabled: true                                                    │
-    └───────────────────────────────────────────────────────────────────────────────────────────┘''');
+    ┌────────────────────────────────────────────────────────────────────────────────────────┐
+    │ Warning:                                                                               │
+    │   The `package_parameter_enabled` property moved from asset to under asset.output.     │
+    │   It should be changed in the following pubspec.yaml.                                  │
+    │   https://github.com/FlutterGen/flutter_gen/pull/294                                   │
+    │                                                                                        │
+    │ [pubspec.yaml]                                                                         │
+    │                                                                                        │
+    │  fluttergen:                                                                           │
+    │    assets:                                                                             │
+    │      outputs:                                                                          │
+    │        package_parameter_enabled: true                                                 │
+    └────────────────────────────────────────────────────────────────────────────────────────┘''');
   }
 
   if (config.flutterGen.assets.outputs.isDotDelimiterStyle) {

--- a/packages/core/lib/settings/config.dart
+++ b/packages/core/lib/settings/config.dart
@@ -54,10 +54,10 @@ flutter_gen:
 
   assets:
     enabled: true
-    package_parameter_enabled: false
-    style: dot-delimiter
     outputs:
       class_name: Assets
+      package_parameter_enabled: false
+      style: dot-delimiter
     exclude: []
     
   fonts:

--- a/packages/core/lib/settings/pubspec.dart
+++ b/packages/core/lib/settings/pubspec.dart
@@ -107,44 +107,30 @@ class FlutterGenColors {
 
 @JsonSerializable()
 class FlutterGenAssets {
-  static const String dotDelimiterStyle = 'dot-delimiter';
-  static const String snakeCaseStyle = 'snake-case';
-  static const String camelCaseStyle = 'camel-case';
-
   FlutterGenAssets({
     required this.enabled,
-    required this.packageParameterEnabled,
-    required this.style,
+    this.packageParameterEnabled,
+    this.style,
     required this.outputs,
     required this.exclude,
-  }) {
-    if (style != dotDelimiterStyle &&
-        style != snakeCaseStyle &&
-        style != camelCaseStyle) {
-      throw ArgumentError.value(style, 'style');
-    }
-  }
+  });
 
   @JsonKey(name: 'enabled', required: true)
   final bool enabled;
 
-  @JsonKey(name: 'package_parameter_enabled', required: true)
-  final bool packageParameterEnabled;
+  @Deprecated('Moved to under outputs')
+  @JsonKey(name: 'package_parameter_enabled', required: false)
+  final bool? packageParameterEnabled;
 
-  @JsonKey(name: 'style', required: true)
-  final String style;
+  @Deprecated('Moved to under outputs')
+  @JsonKey(name: 'style', required: false)
+  final String? style;
 
   @JsonKey(name: 'outputs', required: true)
-  final FlutterGenElementOutputs outputs;
+  final FlutterGenElementAssetsOutputs outputs;
 
   @JsonKey(name: 'exclude', required: true)
   final List<String> exclude;
-
-  bool get isDotDelimiterStyle => style == dotDelimiterStyle;
-
-  bool get isSnakeCaseStyle => style == snakeCaseStyle;
-
-  bool get isCamelCaseStyle => style == camelCaseStyle;
 
   factory FlutterGenAssets.fromJson(Map json) =>
       _$FlutterGenAssetsFromJson(json);
@@ -189,11 +175,47 @@ class FlutterGenIntegrations {
 
 @JsonSerializable()
 class FlutterGenElementOutputs {
-  FlutterGenElementOutputs({required this.className});
+  FlutterGenElementOutputs({
+    required this.className,
+  });
 
   @JsonKey(name: 'class_name', required: true)
   final String className;
 
   factory FlutterGenElementOutputs.fromJson(Map json) =>
       _$FlutterGenElementOutputsFromJson(json);
+}
+
+@JsonSerializable()
+class FlutterGenElementAssetsOutputs extends FlutterGenElementOutputs {
+  static const String dotDelimiterStyle = 'dot-delimiter';
+  static const String snakeCaseStyle = 'snake-case';
+  static const String camelCaseStyle = 'camel-case';
+
+  FlutterGenElementAssetsOutputs({
+    required String className,
+    required this.packageParameterEnabled,
+    required this.style,
+  }) : super(className: className) {
+    if (style != dotDelimiterStyle &&
+        style != snakeCaseStyle &&
+        style != camelCaseStyle) {
+      throw ArgumentError.value(style, 'style');
+    }
+  }
+
+  @JsonKey(name: 'package_parameter_enabled', required: true)
+  final bool packageParameterEnabled;
+
+  @JsonKey(name: 'style', required: true)
+  final String style;
+
+  bool get isDotDelimiterStyle => style == dotDelimiterStyle;
+
+  bool get isSnakeCaseStyle => style == snakeCaseStyle;
+
+  bool get isCamelCaseStyle => style == camelCaseStyle;
+
+  factory FlutterGenElementAssetsOutputs.fromJson(Map json) =>
+      _$FlutterGenElementAssetsOutputsFromJson(json);
 }

--- a/packages/core/lib/settings/pubspec.g.dart
+++ b/packages/core/lib/settings/pubspec.g.dart
@@ -119,21 +119,15 @@ FlutterGenAssets _$FlutterGenAssetsFromJson(Map json) => $checkedCreate(
       ($checkedConvert) {
         $checkKeys(
           json,
-          requiredKeys: const [
-            'enabled',
-            'package_parameter_enabled',
-            'style',
-            'outputs',
-            'exclude'
-          ],
+          requiredKeys: const ['enabled', 'outputs', 'exclude'],
         );
         final val = FlutterGenAssets(
           enabled: $checkedConvert('enabled', (v) => v as bool),
           packageParameterEnabled:
-              $checkedConvert('package_parameter_enabled', (v) => v as bool),
-          style: $checkedConvert('style', (v) => v as String),
-          outputs: $checkedConvert(
-              'outputs', (v) => FlutterGenElementOutputs.fromJson(v as Map)),
+              $checkedConvert('package_parameter_enabled', (v) => v as bool?),
+          style: $checkedConvert('style', (v) => v as String?),
+          outputs: $checkedConvert('outputs',
+              (v) => FlutterGenElementAssetsOutputs.fromJson(v as Map)),
           exclude: $checkedConvert('exclude',
               (v) => (v as List<dynamic>).map((e) => e as String).toList()),
         );
@@ -198,4 +192,32 @@ FlutterGenElementOutputs _$FlutterGenElementOutputsFromJson(Map json) =>
         return val;
       },
       fieldKeyMap: const {'className': 'class_name'},
+    );
+
+FlutterGenElementAssetsOutputs _$FlutterGenElementAssetsOutputsFromJson(
+        Map json) =>
+    $checkedCreate(
+      'FlutterGenElementAssetsOutputs',
+      json,
+      ($checkedConvert) {
+        $checkKeys(
+          json,
+          requiredKeys: const [
+            'class_name',
+            'package_parameter_enabled',
+            'style'
+          ],
+        );
+        final val = FlutterGenElementAssetsOutputs(
+          className: $checkedConvert('class_name', (v) => v as String),
+          packageParameterEnabled:
+              $checkedConvert('package_parameter_enabled', (v) => v as bool),
+          style: $checkedConvert('style', (v) => v as String),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'className': 'class_name',
+        'packageParameterEnabled': 'package_parameter_enabled'
+      },
     );

--- a/packages/core/test_resources/pubspec_assets_camel_case.yaml
+++ b/packages/core/test_resources/pubspec_assets_camel_case.yaml
@@ -5,7 +5,8 @@ flutter_gen:
   line_length: 80   # Optional (default: 80)
 
   assets:
-    style: camel-case
+    outputs:
+      style: camel-case
 
 flutter:
   assets:

--- a/packages/core/test_resources/pubspec_assets_package_parameter.yaml
+++ b/packages/core/test_resources/pubspec_assets_package_parameter.yaml
@@ -4,7 +4,8 @@ flutter_gen:
   integrations:
     flutter_svg: true
   assets:
-    package_parameter_enabled: true
+    outputs:
+      package_parameter_enabled: true
 
 flutter:
   assets:

--- a/packages/core/test_resources/pubspec_assets_package_parameter_disable_null_safety.yaml
+++ b/packages/core/test_resources/pubspec_assets_package_parameter_disable_null_safety.yaml
@@ -4,7 +4,8 @@ flutter_gen:
   integrations:
     flutter_svg: true
   assets:
-    package_parameter_enabled: true
+    outputs:
+      package_parameter_enabled: true
 
 flutter:
   assets:

--- a/packages/core/test_resources/pubspec_assets_snake_case.yaml
+++ b/packages/core/test_resources/pubspec_assets_snake_case.yaml
@@ -5,7 +5,8 @@ flutter_gen:
   line_length: 80   # Optional (default: 80)
 
   assets:
-    style: snake-case
+    outputs:
+      style: snake-case
 
 flutter:
   assets:


### PR DESCRIPTION
### What does this change?

Moved style and package_parameter_enabled settings from asset to under assets.outputs.

**now**
```yaml
flutter_gen:
  # ...
  assets:
    enabled: true
    package_parameter_enabled: true
    style: snake-case
    outputs:
      class_name: MyAssets
```

**`v5.0.0` or later.**
```yaml
flutter_gen:
  # ...
  assets:
    enabled: true
    outputs:
      class_name: MyAssets
      package_parameter_enabled: true
      style: snake-case
```


### Screenshots
**Warning message**
<img width="876" alt="Screen Shot 2022-09-27 at 16 25 20" src="https://user-images.githubusercontent.com/1833474/192461069-114f7f86-025c-4ad4-9bb3-639ae9318f67.png">
