### PR TITLE
feat: add keyName to integrations 

### DIFF
--- a/example/lib/gen/assets.gen.dart
+++ b/example/lib/gen/assets.gen.dart
@@ -304,6 +304,8 @@ class SvgGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }
 
 class FlareGenImage {
@@ -345,6 +347,8 @@ class FlareGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }
 
 class RiveGenImage {
@@ -378,6 +382,8 @@ class RiveGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }
 
 class LottieGenImage {
@@ -435,4 +441,6 @@ class LottieGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,6 +89,10 @@ void main() async {
               // ),
 
               // example_resource package.
+              Text(MyAssets.images.icons.kmm.path),
+              Text(MyAssets.images.icons.kmm.keyName),
+              Text(ResAssets.images.dart.path),
+              Text(ResAssets.images.dart.keyName),
               ResAssets.images.flutter3.image(),
               ResAssets.images.dart.svg(),
               SizedBox(

--- a/example_resources/lib/gen/assets.gen.dart
+++ b/example_resources/lib/gen/assets.gen.dart
@@ -158,7 +158,9 @@ class SvgGenImage {
     );
   }
 
-  String get path => 'packages/example_resources/$_assetName';
+  String get path => _assetName;
+
+  String get keyName => 'packages/example_resources/$_assetName';
 }
 
 class FlareGenImage {
@@ -199,7 +201,9 @@ class FlareGenImage {
     );
   }
 
-  String get path => 'packages/example_resources/$_assetName';
+  String get path => _assetName;
+
+  String get keyName => 'packages/example_resources/$_assetName';
 }
 
 class RiveGenImage {
@@ -232,7 +236,9 @@ class RiveGenImage {
     );
   }
 
-  String get path => 'packages/example_resources/$_assetName';
+  String get path => _assetName;
+
+  String get keyName => 'packages/example_resources/$_assetName';
 }
 
 class LottieGenImage {
@@ -289,5 +295,7 @@ class LottieGenImage {
     );
   }
 
-  String get path => 'packages/example_resources/$_assetName';
+  String get path => _assetName;
+
+  String get keyName => 'packages/example_resources/$_assetName';
 }

--- a/packages/core/lib/generators/integrations/flare_integration.dart
+++ b/packages/core/lib/generators/integrations/flare_integration.dart
@@ -56,7 +56,9 @@ class FlareIntegration extends Integration {
     );
   }
 
-  String get path => ${packageExpression == null ? '_assetName' : '\'$packageExpression\$_assetName\''};
+  String get path => _assetName;
+
+  String get keyName => ${packageExpression == null ? '_assetName' : '\'$packageExpression\$_assetName\''};
 }''';
 
   @override

--- a/packages/core/lib/generators/integrations/lottie_integration.dart
+++ b/packages/core/lib/generators/integrations/lottie_integration.dart
@@ -87,7 +87,9 @@ class LottieIntegration extends Integration {
     );
   }
 
-  String get path => ${packageParameterLiteral.isEmpty ? '_assetName' : '\'packages/$packageParameterLiteral/\$_assetName\''};
+  String get path => _assetName;
+
+  String get keyName => ${packageParameterLiteral.isEmpty ? '_assetName' : '\'packages/$packageParameterLiteral/\$_assetName\''};
 }''';
 
   @override
@@ -120,7 +122,7 @@ class LottieIntegration extends Integration {
     } on FormatException catch (e) {
       // Catches bad/corrupted json and reports it to user.
       stderr.writeln(e.message);
-    } on TypeError catch(e) {
+    } on TypeError catch (e) {
       // Catches bad/corrupted json and reports it to user.
       stderr.writeln(e);
     }

--- a/packages/core/lib/generators/integrations/rive_integration.dart
+++ b/packages/core/lib/generators/integrations/rive_integration.dart
@@ -47,7 +47,9 @@ class RiveIntegration extends Integration {
     );
   }
 
-  String get path => ${packageExpression == null ? '_assetName' : '\'$packageExpression\$_assetName\''};
+  String get path => _assetName;
+
+  String get keyName => ${packageExpression == null ? '_assetName' : '\'$packageExpression\$_assetName\''};
 }''';
 
   @override

--- a/packages/core/lib/generators/integrations/svg_integration.dart
+++ b/packages/core/lib/generators/integrations/svg_integration.dart
@@ -64,7 +64,9 @@ class SvgIntegration extends Integration {
     );
   }
 
-  String get path => ${packageParameterLiteral.isEmpty ? '_assetName' : '\'packages/$packageParameterLiteral/\$_assetName\''};
+  String get path => _assetName;
+
+  String get keyName => ${packageParameterLiteral.isEmpty ? '_assetName' : '\'packages/$packageParameterLiteral/\$_assetName\''};
 }''';
 
   @override

--- a/packages/core/test/colors_gen_test.dart
+++ b/packages/core/test/colors_gen_test.dart
@@ -49,8 +49,7 @@ void main() {
       expect(colorPath.mime, 'application/xml');
       expect(colorPath.isXml, isTrue);
 
-      const wrongColorPath =
-          ColorPath('test_resources/assets/json/map.json');
+      const wrongColorPath = ColorPath('test_resources/assets/json/map.json');
       expect(wrongColorPath.isXml, isFalse);
     });
 

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -261,6 +261,8 @@ class SvgGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }
 
 class FlareGenImage {
@@ -302,4 +304,6 @@ class FlareGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }

--- a/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
@@ -131,4 +131,6 @@ class FlareGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }

--- a/packages/core/test_resources/actual_data/assets_lottie_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_lottie_integrations.gen.dart
@@ -147,4 +147,6 @@ class LottieGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -161,5 +161,7 @@ class SvgGenImage {
     );
   }
 
-  String get path => 'packages/test/$_assetName';
+  String get path => _assetName;
+
+  String get keyName => 'packages/test/$_assetName';
 }

--- a/packages/core/test_resources/actual_data/assets_rive_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_rive_integrations.gen.dart
@@ -122,4 +122,6 @@ class RiveGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -150,4 +150,6 @@ class SvgGenImage {
   }
 
   String get path => _assetName;
+
+  String get keyName => _assetName;
 }


### PR DESCRIPTION
## What does this change?

Fixes #322 🎯

Change to `asset.gen.dart` same properties.

**When package_parameter_enabled = `true`**
```dart
String get path => _assetName;

String get keyName => 'packages/$packageName/\$_assetName';
```

**When package_parameter_enabled  = `false`**
```dart
String get path => _assetName;

String get keyName => _assetName;
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (**BREAKING CHANGES**)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos unit:test-script`)
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [ ] Appropriate docs were updated (if necessary)
