### PR TITLE
Fix missing package on AssetGenImage.provider()

### DIFF
--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -505,6 +505,7 @@ class $className {
 
 String _assetGenImageClassDefinition(String packageName) {
   final packageParameter = packageName.isNotEmpty ? " = '$packageName'" : '';
+  final package = packageName.isNotEmpty ? "'$packageName'" : null;
 
   final keyName = packageName.isEmpty
       ? '_assetName'
@@ -570,7 +571,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: $package);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -207,7 +207,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
@@ -139,7 +139,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_change_class_name.gen.dart
@@ -98,7 +98,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_flare_integrations.gen.dart
@@ -85,7 +85,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
@@ -77,7 +77,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_lottie_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_lottie_integrations.gen.dart
@@ -85,7 +85,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
@@ -168,7 +168,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_package_exclude_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_exclude_files.gen.dart
@@ -127,7 +127,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -108,7 +108,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: 'test');
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_rive_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_rive_integrations.gen.dart
@@ -84,7 +84,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
@@ -140,7 +140,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -96,7 +96,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 

--- a/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
@@ -83,7 +83,7 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider() => AssetImage(_assetName);
+  ImageProvider provider() => AssetImage(_assetName, package: null);
 
   String get path => _assetName;
 


### PR DESCRIPTION
## What does this change?

Generated `AssetGenImage.provider() => AssetImage(_assetName);` should come with `package` that's consistent with `AssetGenImage.image()`.

```dart
AssetGenImage.provider() => AssetImage(_assetName, package: $package);
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

  - [x] Ensure the tests (`melos run unit:test`)
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)

<img width="404" alt="Screen Shot 2023-03-08 at 6 39 03 PM" src="https://user-images.githubusercontent.com/213736/223691372-02f7b771-6d40-4ddd-bcd2-f2921f95ba8f.png">
<img width="367" alt="Screen Shot 2023-03-08 at 6 38 46 PM" src="https://user-images.githubusercontent.com/213736/223691385-fca64800-5d45-45f1-8b9e-ecf200a296a2.png">



