### PR TITLE
remove flutter_svg `clipBehavoir` daprecation close #378

### DIFF
--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -277,9 +277,9 @@ class SvgGenImage {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.none,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    Clip clipBehavior = Clip.none,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -279,7 +279,7 @@ class SvgGenImage {
     ColorFilter? colorFilter,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
+    Clip clipBehavior = Clip.none,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/examples/example/pubspec.yaml
+++ b/examples/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_svg: 2.0.0+1
+  flutter_svg: 2.0.4
   flare_flutter: 3.0.2
   rive: 0.9.1
   lottie: 2.0.0
@@ -107,7 +107,7 @@ dev_dependencies:
   build_runner: ^2.1.11
   freezed: ^2.3.2
   json_serializable: 6.6.1
-  flutter_gen_runner: ^5.2.0
+  flutter_gen_runner: ^5.2.1
 
   flutter_lints: ^2.0.1
 

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -132,9 +132,9 @@ class SvgGenImage {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.none,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    Clip clipBehavior = Clip.none,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -134,7 +134,7 @@ class SvgGenImage {
     ColorFilter? colorFilter,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
+    Clip clipBehavior = Clip.none,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/examples/example_resources/pubspec.yaml
+++ b/examples/example_resources/pubspec.yaml
@@ -13,14 +13,14 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_svg: 2.0.0+1
+  flutter_svg: 2.0.4
   flare_flutter: 3.0.2
   rive: 0.9.1
   lottie: 2.0.0
 
 dev_dependencies:
   build_runner: ^2.1.11
-  flutter_gen_runner: ^5.2.0
+  flutter_gen_runner: ^5.2.1
 
 flutter_gen:
   output: lib/gen/

--- a/packages/command/example/lib/gen/assets.gen.dart
+++ b/packages/command/example/lib/gen/assets.gen.dart
@@ -277,9 +277,9 @@ class SvgGenImage {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.none,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/packages/command/pubspec.yaml
+++ b/packages/command/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 5.2.0
+version: 5.2.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen
@@ -14,7 +14,7 @@ executables:
   fluttergen: flutter_gen_command
 
 dependencies:
-  flutter_gen_core: 5.2.0
+  flutter_gen_core: 5.2.1
   args: '>=2.0.0 <3.0.0'
 
 dev_dependencies:

--- a/packages/core/example/lib/gen/assets.gen.dart
+++ b/packages/core/example/lib/gen/assets.gen.dart
@@ -277,9 +277,9 @@ class SvgGenImage {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.none,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/packages/core/lib/generators/integrations/svg_integration.dart
+++ b/packages/core/lib/generators/integrations/svg_integration.dart
@@ -38,9 +38,9 @@ class SvgIntegration extends Integration {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.none,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_core
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 5.2.0
+version: 5.2.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -234,9 +234,9 @@ class SvgGenImage {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.none,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -135,9 +135,9 @@ class SvgGenImage {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.none,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -123,9 +123,9 @@ class SvgGenImage {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.none,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/packages/runner/example/lib/gen/assets.gen.dart
+++ b/packages/runner/example/lib/gen/assets.gen.dart
@@ -277,9 +277,9 @@ class SvgGenImage {
     bool excludeFromSemantics = false,
     SvgTheme theme = const SvgTheme(),
     ColorFilter? colorFilter,
+    Clip clipBehavior = Clip.non,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
-    @deprecated Clip? clipBehavior,
     @deprecated bool cacheColorFilter = false,
   }) {
     return SvgPicture.asset(

--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_runner
 
 description: The Flutter code generator for your assets, fonts, colors, … — Get rid of all String-based APIs.
-version: 5.2.0
+version: 5.2.1
 homepage: https://github.com/FlutterGen/flutter_gen
 repository: https://github.com/FlutterGen/flutter_gen
 documentation: https://github.com/FlutterGen/flutter_gen


### PR DESCRIPTION
## What does this change?

flutter_svg publish a new version that Reintroduce clipBehavior see [this](https://pub.dev/packages/flutter_svg/changelog#204) this well make a conflict in each time you run the generator because `clipBeavior` argument cannot accept null. this pull request fix this issue.

Fixes #378 🎯

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run unit:test`)
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [x] Appropriate docs were updated (if necessary)
