### PR TITLE
When `packageParameterEnabled` is enabled, include the package name for path assets

### DIFF
--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -15,9 +15,9 @@ import '../utils/string.dart';
 import 'generator_helper.dart';
 import 'integrations/flare_integration.dart';
 import 'integrations/integration.dart';
+import 'integrations/lottie_integration.dart';
 import 'integrations/rive_integration.dart';
 import 'integrations/svg_integration.dart';
-import 'integrations/lottie_integration.dart';
 
 class AssetsGenConfig {
   AssetsGenConfig._(
@@ -244,12 +244,12 @@ AssetType _constructAssetTree(
 }
 
 _Statement? _createAssetTypeStatement(
-  String rootPath,
+  AssetsGenConfig config,
   AssetType assetType,
   List<Integration> integrations,
   String name,
 ) {
-  final childAssetAbsolutePath = join(rootPath, assetType.path);
+  final childAssetAbsolutePath = join(config.rootPath, assetType.path);
   if (assetType.isSupportedImage) {
     return _Statement(
       type: 'AssetGenImage',
@@ -276,11 +276,15 @@ _Statement? _createAssetTypeStatement(
       (element) => element.isSupport(assetType),
     );
     if (integration == null) {
+      var assetKey = posixStyle(assetType.path);
+      if (config.flutterGen.assets.outputs.packageParameterEnabled) {
+        assetKey = 'packages/${config._packageName}/$assetKey';
+      }
       return _Statement(
         type: 'String',
         filePath: assetType.path,
         name: name,
-        value: '\'${posixStyle(assetType.path)}\'',
+        value: '\'$assetKey\'',
         isConstConstructor: false,
         isDirectory: false,
         needDartDoc: true,
@@ -327,7 +331,7 @@ String _dotDelimiterStyleDefinition(
           .mapToIsUniqueWithoutExtension()
           .map(
             (e) => _createAssetTypeStatement(
-              config.rootPath,
+              config,
               e.assetType,
               integrations,
               (e.isUniqueWithoutExtension
@@ -415,7 +419,7 @@ String _flatStyleDefinition(
       .mapToIsUniqueWithoutExtension()
       .map(
         (e) => _createAssetTypeStatement(
-          config.rootPath,
+          config,
           e.assetType,
           integrations,
           createName(e),

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -18,6 +18,17 @@ class $AssetsImagesGen {
   $AssetsImagesIconsGen get icons => const $AssetsImagesIconsGen();
 }
 
+class $AssetsUnknownGen {
+  const $AssetsUnknownGen();
+
+  /// File path: assets/unknown/unknown_mime_type.bk
+  String get unknownMimeType =>
+      'packages/test/assets/unknown/unknown_mime_type.bk';
+
+  /// List of all assets
+  List<String> get values => [unknownMimeType];
+}
+
 class $AssetsImagesChip3Gen {
   const $AssetsImagesChip3Gen();
 
@@ -48,6 +59,7 @@ class Assets {
   Assets._();
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
+  static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }
 
 class AssetGenImage {

--- a/packages/core/test_resources/pubspec_assets_package_parameter.yaml
+++ b/packages/core/test_resources/pubspec_assets_package_parameter.yaml
@@ -12,3 +12,4 @@ flutter:
     - assets/images/chip3/chip3.jpg
     - assets/images/icons/dart@test.svg
     - assets/images/icons/fuchsia.svg
+    - assets/unknown/unknown_mime_type.bk


### PR DESCRIPTION
## What does this change?

This change ensures that when `packageParameterEnabled` is enabled, assets with unknown mime type, for which only the asset key is generated, can be resolved from outside of the containing package.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run unit:test`)
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [ ] Appropriate docs were updated (if necessary)
