### PR TITLE
Include image dimensions in generated AssetGenImage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,32 @@ Widget build(BuildContext context) {
 }
 ```
 
+#### Including additional metadata
+
+At build time, additional metadata may be included in the generated class, by using the
+`parse_metadata` option.
+
+```yaml
+flutter_gen:
+  parse_metadata: true # <- Add this line (default: false)
+```
+
+For image based assets, a new nullable `size` field is added to the
+generated class. For example:
+
+```dart
+AssetGenImage get logo => 
+  const AssetGenImage('assets/images/logo.png', size: Size(209.0, 49.0));
+```
+
+Which can now be used at runtime without parsing the information from the actual asset.
+
+```dart
+Widget build(BuildContext context) {
+  return Assets.images.logo.size!.width;
+}
+```
+
 #### Usage Example
 
 [FlutterGen] generates [Image](https://api.flutter.dev/flutter/widgets/Image-class.html) class if the asset is Flutter supported image format.

--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -193,9 +193,11 @@ class MyAssets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -60,9 +60,11 @@ class ResAssets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/packages/command/example/lib/gen/assets.gen.dart
+++ b/packages/command/example/lib/gen/assets.gen.dart
@@ -193,9 +193,11 @@ class MyAssets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -63,7 +63,8 @@ String generateAssets(
   final integrations = <Integration>[
     ImageIntegration(config.packageParameterLiteral),
     if (config.flutterGen.integrations.flutterSvg)
-      SvgIntegration(config.packageParameterLiteral),
+      SvgIntegration(config.packageParameterLiteral,
+          parseMetadata: config.flutterGen.parseMetadata),
     if (config.flutterGen.integrations.flareFlutter)
       FlareIntegration(config.packageParameterLiteral),
     if (config.flutterGen.integrations.rive)

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -256,7 +256,7 @@ _Statement? _createAssetTypeStatement(
     final childClassName = '\$${assetType.path.camelCase().capitalize()}Gen';
     return _Statement(
       type: childClassName,
-      filePath: assetType.path,
+      filePath: assetType.posixStylePath,
       name: name,
       value: '$childClassName()',
       isConstConstructor: true,
@@ -268,13 +268,13 @@ _Statement? _createAssetTypeStatement(
       (element) => element.isSupport(assetType),
     );
     if (integration == null) {
-      var assetKey = posixStyle(assetType.path);
+      var assetKey = assetType.posixStylePath;
       if (config.flutterGen.assets.outputs.packageParameterEnabled) {
         assetKey = 'packages/${config._packageName}/$assetKey';
       }
       return _Statement(
         type: 'String',
-        filePath: assetType.path,
+        filePath: assetType.posixStylePath,
         name: name,
         value: '\'$assetKey\'',
         isConstConstructor: false,
@@ -285,9 +285,9 @@ _Statement? _createAssetTypeStatement(
       integration.isEnabled = true;
       return _Statement(
         type: integration.className,
-        filePath: assetType.path,
+        filePath: assetType.posixStylePath,
         name: name,
-        value: integration.classInstantiate(posixStyle(assetType.path)),
+        value: integration.classInstantiate(assetType),
         isConstConstructor: integration.isConstConstructor,
         isDirectory: false,
         needDartDoc: true,
@@ -345,7 +345,7 @@ String _dotDelimiterStyleDefinition(
         if (dirname(assetType.path) == '.') {
           assetsStaticStatements.add(_Statement(
             type: className,
-            filePath: assetType.path,
+            filePath: assetType.posixStylePath,
             name: assetType.baseName.camelCase(),
             value: '$className()',
             isConstConstructor: true,
@@ -542,7 +542,7 @@ class _Statement {
   final bool isDirectory;
   final bool needDartDoc;
 
-  String toDartDocString() => '/// File path: ${posixStyle(filePath)}';
+  String toDartDocString() => '/// File path: $filePath';
 
   String toGetterString() =>
       '$type get $name => ${isConstConstructor ? 'const' : ''} $value;';

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -61,7 +61,8 @@ String generateAssets(
   final classesBuffer = StringBuffer();
 
   final integrations = <Integration>[
-    ImageIntegration(config.packageParameterLiteral),
+    ImageIntegration(config.packageParameterLiteral,
+        parseMetadata: config.flutterGen.parseMetadata),
     if (config.flutterGen.integrations.flutterSvg)
       SvgIntegration(config.packageParameterLiteral,
           parseMetadata: config.flutterGen.parseMetadata),

--- a/packages/core/lib/generators/generator_helper.dart
+++ b/packages/core/lib/generators/generator_helper.dart
@@ -16,6 +16,3 @@ String get ignore {
 }
 
 String import(String package) => 'import \'$package\';';
-
-// Replace to Posix style for Windows separator.
-String posixStyle(String path) => path.replaceAll(r'\', r'/');

--- a/packages/core/lib/generators/integrations/flare_integration.dart
+++ b/packages/core/lib/generators/integrations/flare_integration.dart
@@ -64,10 +64,11 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
   String get className => 'FlareGenImage';
 
   @override
-  String classInstantiate(String path) => 'FlareGenImage(\'$path\')';
+  String classInstantiate(AssetType asset) =>
+      'FlareGenImage(\'${asset.posixStylePath}\')';
 
   @override
-  bool isSupport(AssetType type) => type.extension == '.flr';
+  bool isSupport(AssetType asset) => asset.extension == '.flr';
 
   @override
   bool get isConstConstructor => true;

--- a/packages/core/lib/generators/integrations/image_integration.dart
+++ b/packages/core/lib/generators/integrations/image_integration.dart
@@ -101,7 +101,8 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
   String get className => 'AssetGenImage';
 
   @override
-  String classInstantiate(String path) => 'AssetGenImage(\'$path\')';
+  String classInstantiate(AssetType asset) =>
+      'AssetGenImage(\'${asset.posixStylePath}\')';
 
   @override
   bool isSupport(AssetType type) {

--- a/packages/core/lib/generators/integrations/integration.dart
+++ b/packages/core/lib/generators/integrations/integration.dart
@@ -39,5 +39,5 @@ class ImageMetadata {
   final double width;
   final double height;
 
-  ImageMetadata(this.width, this.height);
+  const ImageMetadata(this.width, this.height);
 }

--- a/packages/core/lib/generators/integrations/integration.dart
+++ b/packages/core/lib/generators/integrations/integration.dart
@@ -3,13 +3,15 @@ import 'package:flutter_gen_core/settings/asset_type.dart';
 /// A base class for all integrations. An integration is a class that
 /// generates code for a specific asset type.
 abstract class Integration {
-  Integration(this.packageName);
+  Integration(this.packageName, {this.parseMetadata = false});
 
   /// The package name for this asset. If empty, the asset is not in a package.
   final String packageName;
   late final bool isPackage = packageName.isNotEmpty;
 
   bool isEnabled = false;
+
+  final bool parseMetadata;
 
   List<String> get requiredImports;
 
@@ -29,3 +31,14 @@ abstract class Integration {
 /// if the asset is a library asset.
 const String deprecationMessagePackage =
     "@Deprecated('Do not specify package for a generated library asset')";
+
+/// Useful metadata about the a parsed Asset file. Which is used when
+/// [parseMetadata] is true.
+/// Currently only contains the width and height, but could contain more in
+/// future.
+class ImageMetadata {
+  final double width;
+  final double height;
+
+  ImageMetadata(this.width, this.height);
+}

--- a/packages/core/lib/generators/integrations/integration.dart
+++ b/packages/core/lib/generators/integrations/integration.dart
@@ -17,10 +17,10 @@ abstract class Integration {
 
   String get className;
 
-  String classInstantiate(String path);
+  String classInstantiate(AssetType asset);
 
   /// Is this asset type supported by this integration?
-  bool isSupport(AssetType type);
+  bool isSupport(AssetType asset);
 
   bool get isConstConstructor;
 }

--- a/packages/core/lib/generators/integrations/integration.dart
+++ b/packages/core/lib/generators/integrations/integration.dart
@@ -32,8 +32,7 @@ abstract class Integration {
 const String deprecationMessagePackage =
     "@Deprecated('Do not specify package for a generated library asset')";
 
-/// Useful metadata about the a parsed Asset file. Which is used when
-/// [parseMetadata] is true.
+/// Useful metadata about the parsed asset file when [parseMetadata] is true.
 /// Currently only contains the width and height, but could contain more in
 /// future.
 class ImageMetadata {

--- a/packages/core/lib/generators/integrations/lottie_integration.dart
+++ b/packages/core/lib/generators/integrations/lottie_integration.dart
@@ -96,10 +96,11 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
   String get className => 'LottieGenImage';
 
   @override
-  String classInstantiate(String path) => 'LottieGenImage(\'$path\')';
+  String classInstantiate(AssetType asset) =>
+      'LottieGenImage(\'${asset.posixStylePath}\')';
 
   @override
-  bool isSupport(AssetType type) => isLottieFile(type);
+  bool isSupport(AssetType asset) => isLottieFile(asset);
 
   @override
   bool get isConstConstructor => true;

--- a/packages/core/lib/generators/integrations/rive_integration.dart
+++ b/packages/core/lib/generators/integrations/rive_integration.dart
@@ -55,10 +55,11 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
   String get className => 'RiveGenImage';
 
   @override
-  String classInstantiate(String path) => 'RiveGenImage(\'$path\')';
+  String classInstantiate(AssetType asset) =>
+      'RiveGenImage(\'${asset.posixStylePath}\')';
 
   @override
-  bool isSupport(AssetType type) => type.extension == '.riv';
+  bool isSupport(AssetType asset) => asset.extension == '.riv';
 
   @override
   bool get isConstConstructor => true;

--- a/packages/core/lib/generators/integrations/svg_integration.dart
+++ b/packages/core/lib/generators/integrations/svg_integration.dart
@@ -76,10 +76,11 @@ class SvgIntegration extends Integration {
   String get className => 'SvgGenImage';
 
   @override
-  String classInstantiate(String path) => 'SvgGenImage(\'$path\')';
+  String classInstantiate(AssetType asset) =>
+      'SvgGenImage(\'${asset.posixStylePath}\')';
 
   @override
-  bool isSupport(AssetType type) => type.mime == 'image/svg+xml';
+  bool isSupport(AssetType asset) => asset.mime == 'image/svg+xml';
 
   @override
   bool get isConstConstructor => true;

--- a/packages/core/lib/generators/integrations/svg_integration.dart
+++ b/packages/core/lib/generators/integrations/svg_integration.dart
@@ -5,12 +5,10 @@ import 'package:flutter_gen_core/settings/asset_type.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
 
 class SvgIntegration extends Integration {
-  SvgIntegration(String packageName, {this.parseMetadata = false})
+  SvgIntegration(String packageName, {super.parseMetadata})
       : super(packageName);
 
   String get packageExpression => isPackage ? ' = package' : '';
-
-  final bool parseMetadata;
 
   @override
   List<String> get requiredImports => [
@@ -26,8 +24,9 @@ class SvgIntegration extends Integration {
   const SvgGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
-  final Size? size;
 ${isPackage ? "\n  static const String package = '$packageName';" : ''}
+
+  final Size? size;
 
   SvgPicture svg({
     Key? key,
@@ -84,21 +83,21 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
   @override
   String classInstantiate(AssetType asset) {
     // Query extra information about the SVG
-    SvgInfo? info = parseMetadata ? _getMetadata(asset) : null;
+    ImageMetadata? info = parseMetadata ? _getMetadata(asset) : null;
 
     return 'SvgGenImage(\'${asset.posixStylePath}\''
         '${(info != null) ? ', size: Size(${info.width}, ${info.height})' : ''}'
         ')';
   }
 
-  SvgInfo? _getMetadata(AssetType asset) {
+  ImageMetadata? _getMetadata(AssetType asset) {
     try {
       // The SVG file is read fully, then parsed with the vector_graphics
       // library. This is quite a heavy way to extract just the dimenions, but
       // it's also the same way it will be eventually rendered by Flutter.
       final svg = File(asset.fullPath).readAsStringSync();
       final vec = parseWithoutOptimizers(svg);
-      return SvgInfo(vec.width, vec.height);
+      return ImageMetadata(vec.width, vec.height);
     } catch (e) {
       stderr.writeln(
           '[WARNING] Failed to parse SVG \'${asset.path}\' metadata: $e');
@@ -112,13 +111,4 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
 
   @override
   bool get isConstConstructor => true;
-}
-
-/// Useful metadata about the a parsed SVG file.
-/// Currently only contains the width and height.
-class SvgInfo {
-  final double width;
-  final double height;
-
-  SvgInfo(this.width, this.height);
 }

--- a/packages/core/lib/settings/asset_type.dart
+++ b/packages/core/lib/settings/asset_type.dart
@@ -1,6 +1,7 @@
 import 'package:dartx/dartx.dart';
 import 'package:mime/mime.dart';
 import 'package:path/path.dart' as p;
+import 'package:path/path.dart';
 
 /// https://github.com/dart-lang/mime/blob/master/lib/src/default_extension_map.dart
 class AssetType {
@@ -35,6 +36,12 @@ class AssetType {
   String get extension => p.extension(path);
 
   String get baseName => p.basenameWithoutExtension(path);
+
+  /// Returns the full absolute path for reading the asset file.
+  String get fullPath => join(rootPath, path);
+
+  // Replace to Posix style for Windows separator.
+  String get posixStylePath => path.replaceAll(r'\', r'/');
 
   List<AssetType> get children => _children.sortedBy((e) => e.path);
 

--- a/packages/core/lib/settings/config_default.dart
+++ b/packages/core/lib/settings/config_default.dart
@@ -6,6 +6,8 @@ flutter_gen:
   output: lib/gen/
   # Optional
   line_length: 80
+  # Optional
+  parse_metadata: false
 
   # Optional
   integrations:

--- a/packages/core/lib/settings/pubspec.dart
+++ b/packages/core/lib/settings/pubspec.dart
@@ -55,6 +55,7 @@ class FlutterGen {
   FlutterGen({
     required this.output,
     required this.lineLength,
+    required this.parseMetadata,
     required this.assets,
     required this.fonts,
     required this.integrations,
@@ -66,6 +67,9 @@ class FlutterGen {
 
   @JsonKey(name: 'line_length', required: true)
   final int lineLength;
+
+  @JsonKey(name: 'parse_metadata', required: true)
+  final bool parseMetadata;
 
   @JsonKey(name: 'assets', required: true)
   final FlutterGenAssets assets;

--- a/packages/core/lib/settings/pubspec.g.dart
+++ b/packages/core/lib/settings/pubspec.g.dart
@@ -71,6 +71,7 @@ FlutterGen _$FlutterGenFromJson(Map json) => $checkedCreate(
           requiredKeys: const [
             'output',
             'line_length',
+            'parse_metadata',
             'assets',
             'fonts',
             'integrations',
@@ -80,6 +81,7 @@ FlutterGen _$FlutterGenFromJson(Map json) => $checkedCreate(
         final val = FlutterGen(
           output: $checkedConvert('output', (v) => v as String),
           lineLength: $checkedConvert('line_length', (v) => v as int),
+          parseMetadata: $checkedConvert('parse_metadata', (v) => v as bool),
           assets: $checkedConvert(
               'assets', (v) => FlutterGenAssets.fromJson(v as Map)),
           fonts: $checkedConvert(
@@ -91,7 +93,10 @@ FlutterGen _$FlutterGenFromJson(Map json) => $checkedCreate(
         );
         return val;
       },
-      fieldKeyMap: const {'lineLength': 'line_length'},
+      fieldKeyMap: const {
+        'lineLength': 'line_length',
+        'parseMetadata': 'parse_metadata'
+      },
     );
 
 FlutterGenColors _$FlutterGenColorsFromJson(Map json) => $checkedCreate(

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   dart_style: ^2.2.4
   args: ^2.0.0
   pub_semver: ^2.0.0
+  vector_graphics_compiler: ^1.1.9
 
 dev_dependencies:
   lints: any # Ignoring the version to allow editing across SDK versions.

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   args: ^2.0.0
   pub_semver: ^2.0.0
   vector_graphics_compiler: ^1.1.9
+  image_size_getter: ^2.1.2
 
 dev_dependencies:
   lints: any # Ignoring the version to allow editing across SDK versions.

--- a/packages/core/test/assets_gen_integrations_test.dart
+++ b/packages/core/test/assets_gen_integrations_test.dart
@@ -33,7 +33,8 @@ void main() {
       final integration = SvgIntegration('');
       expect(integration.className, 'SvgGenImage');
       expect(
-        integration.classInstantiate('assets/path'),
+        integration.classInstantiate(
+            AssetType(rootPath: resPath, path: 'assets/path')),
         'SvgGenImage(\'assets/path\')',
       );
       expect(
@@ -73,7 +74,9 @@ void main() {
 
       final integration = FlareIntegration('');
       expect(integration.className, 'FlareGenImage');
-      expect(integration.classInstantiate('assets/path'),
+      expect(
+          integration.classInstantiate(
+              AssetType(rootPath: resPath, path: 'assets/path')),
           'FlareGenImage(\'assets/path\')');
       expect(
           integration.isSupport(
@@ -105,7 +108,9 @@ void main() {
 
       final integration = RiveIntegration('');
       expect(integration.className, 'RiveGenImage');
-      expect(integration.classInstantiate('assets/path'),
+      expect(
+          integration.classInstantiate(
+              AssetType(rootPath: resPath, path: 'assets/path')),
           'RiveGenImage(\'assets/path\')');
       expect(
           integration.isSupport(
@@ -137,7 +142,9 @@ void main() {
 
       final integration = LottieIntegration('');
       expect(integration.className, 'LottieGenImage');
-      expect(integration.classInstantiate('assets/lottie'),
+      expect(
+          integration.classInstantiate(
+              AssetType(rootPath: resPath, path: 'assets/lottie')),
           'LottieGenImage(\'assets/lottie\')');
       expect(
           integration.isSupport(AssetType(

--- a/packages/core/test/assets_gen_test.dart
+++ b/packages/core/test/assets_gen_test.dart
@@ -108,6 +108,14 @@ void main() {
 
       await expectedAssetsGen(pubspec, generated, fact);
     });
+
+    test('Assets with parse metadata enabled', () async {
+      const pubspec = 'test_resources/pubspec_assets_parse_metadata.yaml';
+      const fact = 'test_resources/actual_data/assets_parse_metadata.gen.dart';
+      const generated = 'test_resources/lib/gen/assets_parse_metadata.gen.dart';
+
+      await expectedAssetsGen(pubspec, generated, fact);
+    });
   });
 
   group('Test generatePackageNameForConfig', () {

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -224,9 +224,10 @@ class AssetGenImage {
 }
 
 class SvgGenImage {
-  const SvgGenImage(this._assetName);
+  const SvgGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+  final Size? size;
 
   SvgPicture svg({
     Key? key,

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -150,9 +150,11 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,
@@ -227,6 +229,7 @@ class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
   final Size? size;
 
   SvgPicture svg({

--- a/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
@@ -82,9 +82,11 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/packages/core/test_resources/actual_data/assets_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_change_class_name.gen.dart
@@ -41,9 +41,11 @@ class MyAssets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
@@ -111,9 +111,11 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/packages/core/test_resources/actual_data/assets_package_exclude_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_exclude_files.gen.dart
@@ -70,9 +70,11 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -65,11 +65,13 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
 
   static const String package = 'test';
+
+  final Size? size;
 
   Image image({
     Key? key,
@@ -146,9 +148,10 @@ class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
-  final Size? size;
 
   static const String package = 'test';
+
+  final Size? size;
 
   SvgPicture svg({
     Key? key,

--- a/packages/core/test_resources/actual_data/assets_parse_metadata.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_parse_metadata.gen.dart
@@ -10,20 +10,86 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter/services.dart';
+import 'package:flare_flutter/flare_actor.dart';
+import 'package:flare_flutter/flare_controller.dart';
+
+class $PicturesGen {
+  const $PicturesGen();
+
+  /// File path: pictures/chip5.jpg
+  AssetGenImage get chip5 => const AssetGenImage('pictures/chip5.jpg');
+
+  /// List of all assets
+  List<AssetGenImage> get values => [chip5];
+}
+
+class $AssetsFlareGen {
+  const $AssetsFlareGen();
+
+  /// File path: assets/flare/Penguin.flr
+  FlareGenImage get penguin => const FlareGenImage('assets/flare/Penguin.flr');
+
+  /// List of all assets
+  List<FlareGenImage> get values => [penguin];
+}
 
 class $AssetsImagesGen {
   const $AssetsImagesGen();
 
+  /// File path: assets/images/chip1.jpg
+  AssetGenImage get chip1 => const AssetGenImage('assets/images/chip1.jpg');
+
+  /// File path: assets/images/chip2.jpg
+  AssetGenImage get chip2 => const AssetGenImage('assets/images/chip2.jpg');
+
   $AssetsImagesChip3Gen get chip3 => const $AssetsImagesChip3Gen();
+  $AssetsImagesChip4Gen get chip4 => const $AssetsImagesChip4Gen();
   $AssetsImagesIconsGen get icons => const $AssetsImagesIconsGen();
+
+  /// File path: assets/images/logo.png
+  AssetGenImage get logo => const AssetGenImage('assets/images/logo.png');
+
+  /// File path: assets/images/profile.jpg
+  AssetGenImage get profileJpg =>
+      const AssetGenImage('assets/images/profile.jpg');
+
+  /// File path: assets/images/profile.png
+  AssetGenImage get profilePng =>
+      const AssetGenImage('assets/images/profile.png');
+
+  /// List of all assets
+  List<AssetGenImage> get values =>
+      [chip1, chip2, logo, profileJpg, profilePng];
+}
+
+class $AssetsJsonGen {
+  const $AssetsJsonGen();
+
+  /// File path: assets/json/list.json
+  String get list => 'assets/json/list.json';
+
+  /// File path: assets/json/map.json
+  String get map => 'assets/json/map.json';
+
+  /// List of all assets
+  List<String> get values => [list, map];
+}
+
+class $AssetsMovieGen {
+  const $AssetsMovieGen();
+
+  /// File path: assets/movie/the_earth.mp4
+  String get theEarth => 'assets/movie/the_earth.mp4';
+
+  /// List of all assets
+  List<String> get values => [theEarth];
 }
 
 class $AssetsUnknownGen {
   const $AssetsUnknownGen();
 
   /// File path: assets/unknown/unknown_mime_type.bk
-  String get unknownMimeType =>
-      'packages/test/assets/unknown/unknown_mime_type.bk';
+  String get unknownMimeType => 'assets/unknown/unknown_mime_type.bk';
 
   /// List of all assets
   List<String> get values => [unknownMimeType];
@@ -40,36 +106,61 @@ class $AssetsImagesChip3Gen {
   List<AssetGenImage> get values => [chip3];
 }
 
+class $AssetsImagesChip4Gen {
+  const $AssetsImagesChip4Gen();
+
+  /// File path: assets/images/chip4/chip4.jpg
+  AssetGenImage get chip4 =>
+      const AssetGenImage('assets/images/chip4/chip4.jpg');
+
+  /// List of all assets
+  List<AssetGenImage> get values => [chip4];
+}
+
 class $AssetsImagesIconsGen {
   const $AssetsImagesIconsGen();
 
   /// File path: assets/images/icons/dart@test.svg
   SvgGenImage get dartTest =>
-      const SvgGenImage('assets/images/icons/dart@test.svg');
+      const SvgGenImage('assets/images/icons/dart@test.svg',
+          size: Size(512.001, 512.001));
 
   /// File path: assets/images/icons/fuchsia.svg
   SvgGenImage get fuchsia =>
-      const SvgGenImage('assets/images/icons/fuchsia.svg');
+      const SvgGenImage('assets/images/icons/fuchsia.svg',
+          size: Size(50.0, 50.0));
+
+  /// File path: assets/images/icons/invalid.svg
+  SvgGenImage get invalid =>
+      const SvgGenImage('assets/images/icons/invalid.svg');
+
+  /// File path: assets/images/icons/kmm.svg
+  SvgGenImage get kmm => const SvgGenImage('assets/images/icons/kmm.svg',
+      size: Size(755.0, 310.0));
+
+  /// File path: assets/images/icons/paint.svg
+  SvgGenImage get paint => const SvgGenImage('assets/images/icons/paint.svg',
+      size: Size(472.0, 392.0));
 
   /// List of all assets
-  List<SvgGenImage> get values => [dartTest, fuchsia];
+  List<SvgGenImage> get values => [dartTest, fuchsia, invalid, kmm, paint];
 }
 
 class Assets {
   Assets._();
 
-  static const String package = 'test';
-
+  static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
+  static const $AssetsJsonGen json = $AssetsJsonGen();
+  static const $AssetsMovieGen movie = $AssetsMovieGen();
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
+  static const $PicturesGen pictures = $PicturesGen();
 }
 
 class AssetGenImage {
   const AssetGenImage(this._assetName);
 
   final String _assetName;
-
-  static const String package = 'test';
 
   Image image({
     Key? key,
@@ -91,8 +182,7 @@ class AssetGenImage {
     bool matchTextDirection = false,
     bool gaplessPlayback = false,
     bool isAntiAlias = false,
-    @Deprecated('Do not specify package for a generated library asset')
-    String? package = package,
+    String? package,
     FilterQuality filterQuality = FilterQuality.low,
     int? cacheWidth,
     int? cacheHeight,
@@ -127,8 +217,7 @@ class AssetGenImage {
 
   ImageProvider provider({
     AssetBundle? bundle,
-    @Deprecated('Do not specify package for a generated library asset')
-    String? package = package,
+    String? package,
   }) {
     return AssetImage(
       _assetName,
@@ -139,7 +228,7 @@ class AssetGenImage {
 
   String get path => _assetName;
 
-  String get keyName => 'packages/test/$_assetName';
+  String get keyName => _assetName;
 }
 
 class SvgGenImage {
@@ -148,14 +237,11 @@ class SvgGenImage {
   final String _assetName;
   final Size? size;
 
-  static const String package = 'test';
-
   SvgPicture svg({
     Key? key,
     bool matchTextDirection = false,
     AssetBundle? bundle,
-    @Deprecated('Do not specify package for a generated library asset')
-    String? package = package,
+    String? package,
     double? width,
     double? height,
     BoxFit fit = BoxFit.contain,
@@ -196,5 +282,48 @@ class SvgGenImage {
 
   String get path => _assetName;
 
-  String get keyName => 'packages/test/$_assetName';
+  String get keyName => _assetName;
+}
+
+class FlareGenImage {
+  const FlareGenImage(this._assetName);
+
+  final String _assetName;
+
+  FlareActor flare({
+    String? boundsNode,
+    String? animation,
+    BoxFit fit = BoxFit.contain,
+    Alignment alignment = Alignment.center,
+    bool isPaused = false,
+    bool snapToEnd = false,
+    FlareController? controller,
+    FlareCompletedCallback? callback,
+    Color? color,
+    bool shouldClip = true,
+    bool sizeFromArtboard = false,
+    String? artboard,
+    bool antialias = true,
+  }) {
+    return FlareActor(
+      _assetName,
+      boundsNode: boundsNode,
+      animation: animation,
+      fit: fit,
+      alignment: alignment,
+      isPaused: isPaused,
+      snapToEnd: snapToEnd,
+      controller: controller,
+      callback: callback,
+      color: color,
+      shouldClip: shouldClip,
+      sizeFromArtboard: sizeFromArtboard,
+      artboard: artboard,
+      antialias: antialias,
+    );
+  }
+
+  String get path => _assetName;
+
+  String get keyName => _assetName;
 }

--- a/packages/core/test_resources/actual_data/assets_parse_metadata.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_parse_metadata.gen.dart
@@ -17,7 +17,8 @@ class $PicturesGen {
   const $PicturesGen();
 
   /// File path: pictures/chip5.jpg
-  AssetGenImage get chip5 => const AssetGenImage('pictures/chip5.jpg');
+  AssetGenImage get chip5 =>
+      const AssetGenImage('pictures/chip5.jpg', size: Size(600.0, 403.0));
 
   /// List of all assets
   List<AssetGenImage> get values => [chip5];
@@ -37,7 +38,8 @@ class $AssetsImagesGen {
   const $AssetsImagesGen();
 
   /// File path: assets/images/chip1.jpg
-  AssetGenImage get chip1 => const AssetGenImage('assets/images/chip1.jpg');
+  AssetGenImage get chip1 =>
+      const AssetGenImage('assets/images/chip1.jpg', size: Size(600.0, 403.0));
 
   /// File path: assets/images/chip2.jpg
   AssetGenImage get chip2 => const AssetGenImage('assets/images/chip2.jpg');
@@ -47,7 +49,8 @@ class $AssetsImagesGen {
   $AssetsImagesIconsGen get icons => const $AssetsImagesIconsGen();
 
   /// File path: assets/images/logo.png
-  AssetGenImage get logo => const AssetGenImage('assets/images/logo.png');
+  AssetGenImage get logo =>
+      const AssetGenImage('assets/images/logo.png', size: Size(209.0, 49.0));
 
   /// File path: assets/images/profile.jpg
   AssetGenImage get profileJpg =>
@@ -100,7 +103,8 @@ class $AssetsImagesChip3Gen {
 
   /// File path: assets/images/chip3/chip3.jpg
   AssetGenImage get chip3 =>
-      const AssetGenImage('assets/images/chip3/chip3.jpg');
+      const AssetGenImage('assets/images/chip3/chip3.jpg',
+          size: Size(600.0, 403.0));
 
   /// List of all assets
   List<AssetGenImage> get values => [chip3];
@@ -111,7 +115,8 @@ class $AssetsImagesChip4Gen {
 
   /// File path: assets/images/chip4/chip4.jpg
   AssetGenImage get chip4 =>
-      const AssetGenImage('assets/images/chip4/chip4.jpg');
+      const AssetGenImage('assets/images/chip4/chip4.jpg',
+          size: Size(600.0, 403.0));
 
   /// List of all assets
   List<AssetGenImage> get values => [chip4];
@@ -158,9 +163,11 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,
@@ -235,6 +242,7 @@ class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
   final Size? size;
 
   SvgPicture svg({

--- a/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
@@ -83,9 +83,11 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -39,9 +39,10 @@ class Assets {
 }
 
 class SvgGenImage {
-  const SvgGenImage(this._assetName);
+  const SvgGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+  final Size? size;
 
   SvgPicture svg({
     Key? key,

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -42,6 +42,7 @@ class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
   final Size? size;
 
   SvgPicture svg({

--- a/packages/core/test_resources/assets/images/icons/invalid.svg
+++ b/packages/core/test_resources/assets/images/icons/invalid.svg
@@ -1,0 +1,1 @@
+<this>is not a valid SVG file</this>

--- a/packages/core/test_resources/pubspec_assets_parse_metadata.yaml
+++ b/packages/core/test_resources/pubspec_assets_parse_metadata.yaml
@@ -1,0 +1,27 @@
+name: test
+
+flutter_gen:
+  output: lib/gen/ # Optional (default: lib/gen/)
+  line_length: 80 # Optional (default: 80)
+  parse_metadata: true # Optional (default: true)
+
+  integrations:
+    flutter_svg: true
+    flare_flutter: true
+
+flutter:
+  assets:
+    - assets/images
+    - assets/images/chip3/chip3.jpg
+    - assets/images/chip3/chip3.jpg # duplicated
+    - assets/images/chip4/
+    - assets/images/icons/fuchsia.svg
+    - assets/images/icons/kmm.svg
+    - assets/images/icons/paint.svg
+    - assets/images/icons/dart@test.svg
+    - assets/images/icons/invalid.svg
+    - assets/json/
+    - pictures/chip5.jpg
+    - assets/flare/
+    - assets/movie/
+    - assets/unknown/unknown_mime_type.bk

--- a/packages/core/test_resources/pubspec_assets_parse_metadata.yaml
+++ b/packages/core/test_resources/pubspec_assets_parse_metadata.yaml
@@ -3,7 +3,7 @@ name: test
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
   line_length: 80 # Optional (default: 80)
-  parse_metadata: true # Optional (default: true)
+  parse_metadata: true # Optional (default: false)
 
   integrations:
     flutter_svg: true

--- a/packages/runner/example/lib/gen/assets.gen.dart
+++ b/packages/runner/example/lib/gen/assets.gen.dart
@@ -193,9 +193,11 @@ class MyAssets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName);
+  const AssetGenImage(this._assetName, {this.size = null});
 
   final String _assetName;
+
+  final Size? size;
 
   Image image({
     Key? key,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_repository
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: ">=2.17.0 <4.0.0"
 
 dev_dependencies:
   lints: any # Ignoring the version to allow editing across SDK versions.


### PR DESCRIPTION
## What does this change?

This adds a new config `parse_metadata` which at build time determines the dimensions of image assets and includes them in the generated `AssetGenImage` class.

Before this change you'd need to do this: (taken from [StackOverflow](https://stackoverflow.com/a/65096977/88646)):

```dart
final Image image = Image(image: AssetImage(Assets.images.someimage.path));
Completer<ui.Image> completer = new Completer<ui.Image>();
    image.image
        .resolve(new ImageConfiguration())
        .addListener(new ImageStreamListener((ImageInfo image, bool _) {
      completer.complete(image.image);
    }));
ui.Image info = await completer.future;
print("${info.width} x ${info.height};
```

After this change you can now easily do

```dart
print(Assets.images.someimage.size)
```

So far this only works for SVGs, but it'll be easy to add the other types, and include other metadata (not just dimension if deemed useful).

Fixes #402🎯

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run unit:test`) **<-- I think this is just `melos test`**
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [ ] Appropriate docs were updated (if necessary)
