### PR TITLE
More robustly pick valid unique names for each asset.

### DIFF
--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -255,7 +255,7 @@ AssetType _constructAssetTree(
 
 _Statement? _createAssetTypeStatement(
   AssetsGenConfig config,
-  AssetType assetType,
+  UniqueAssetType assetType,
   List<Integration> integrations,
 ) {
   final childAssetAbsolutePath = join(config.rootPath, assetType.path);
@@ -337,11 +337,11 @@ String _dotDelimiterStyleDefinition(
     // Handles directories, and explicitly handles root path assets.
     if (isDirectory || isRootAsset) {
       final statements = assetType.children
-          .mapToIsUniqueWithoutExtension()
+          .mapToUniqueAssetType(camelCase, justBasename: true)
           .map(
             (e) => _createAssetTypeStatement(
               config,
-              e.assetType,
+              e,
               integrations,
             ),
           )
@@ -355,7 +355,7 @@ String _dotDelimiterStyleDefinition(
         assetsStaticStatements.add(
           _createAssetTypeStatement(
             config,
-            assetType,
+            UniqueAssetType(assetType: assetType, style: camelCase),
             integrations,
           )!,
         );
@@ -399,18 +399,8 @@ String _camelCaseStyleDefinition(
   return _flatStyleDefinition(
     config,
     integrations,
-    _camelCaseStyleName,
+    camelCase,
   );
-}
-
-String _camelCaseStyleName(AssetTypeIsUniqueWithoutExtension e) {
-  return (e.isUniqueWithoutExtension
-          ? withoutExtension(e.assetType.path)
-          : e.assetType.path)
-
-      // Omit root directory from the name if it is either assets or asset.
-      .replaceFirst(RegExp(r'asset(s)?'), '')
-      .camelCase();
 }
 
 /// Generate style like Assets.foo_bar
@@ -421,24 +411,14 @@ String _snakeCaseStyleDefinition(
   return _flatStyleDefinition(
     config,
     integrations,
-    _snakeCaseStyleName,
+    snakeCase,
   );
-}
-
-String _snakeCaseStyleName(AssetTypeIsUniqueWithoutExtension e) {
-  return (e.isUniqueWithoutExtension
-          ? withoutExtension(e.assetType.path)
-          : e.assetType.path)
-
-      // Omit root directory from the name if it is either assets or asset.
-      .replaceFirst(RegExp(r'asset(s)?'), '')
-      .snakeCase();
 }
 
 String _flatStyleDefinition(
   AssetsGenConfig config,
   List<Integration> integrations,
-  String Function(AssetTypeIsUniqueWithoutExtension) createName,
+  String Function(String) style,
 ) {
   final statements = _getAssetRelativePathList(
     config.rootPath,
@@ -448,11 +428,11 @@ String _flatStyleDefinition(
       .distinct()
       .sorted()
       .map((assetPath) => AssetType(rootPath: config.rootPath, path: assetPath))
-      .mapToIsUniqueWithoutExtension()
+      .mapToUniqueAssetType(style)
       .map(
         (e) => _createAssetTypeStatement(
           config,
-          e.assetType,
+          e,
           integrations,
         ),
       )

--- a/packages/core/lib/settings/asset_type.dart
+++ b/packages/core/lib/settings/asset_type.dart
@@ -48,6 +48,11 @@ class AssetType {
   void addChild(AssetType type) {
     _children.add(type);
   }
+
+  /// Returns a name for this asset.
+  String get name {
+    return withoutExtension(path);
+  }
 }
 
 class AssetTypeIsUniqueWithoutExtension {

--- a/packages/core/lib/settings/asset_type.dart
+++ b/packages/core/lib/settings/asset_type.dart
@@ -1,4 +1,6 @@
 import 'package:dartx/dartx.dart';
+import 'package:flutter_gen_core/utils/identifer.dart';
+import 'package:flutter_gen_core/utils/string.dart';
 import 'package:mime/mime.dart';
 import 'package:path/path.dart' as p;
 import 'package:path/path.dart';
@@ -55,28 +57,150 @@ class AssetType {
   }
 }
 
-class AssetTypeIsUniqueWithoutExtension {
-  AssetTypeIsUniqueWithoutExtension({
-    required this.assetType,
-    required this.isUniqueWithoutExtension,
-  });
+/// Represents a AssetType with modifiers on it to mutate the [name] to ensure
+/// it is unique in a larger list and a valid dart identifer.
+///
+/// See [AssetTypeIterable.mapToUniqueAssetType] for the algorithm.
+class UniqueAssetType extends AssetType {
+  UniqueAssetType({
+    required AssetType assetType,
+    this.style = camelCase,
+    this.justBasename = false,
+    this.needExtension = false,
+    this.suffix = '',
+  }) : super(rootPath: assetType.rootPath, path: assetType.path);
 
-  final AssetType assetType;
-  final bool isUniqueWithoutExtension;
+  /// Convert the asset name to a correctly styled name, e.g camelCase or
+  /// snakeCase.
+  final String Function(String) style;
+
+  /// Include just the basename of the asset in the [name],
+  /// e.g. 'images/image.png' -> 'image'.
+  final bool justBasename;
+
+  /// Include the extension in the [name], e.g. 'image.png' -> 'imagePng'.
+  bool needExtension;
+
+  /// Optional suffix to append to the [name] to make it unique. Typically just
+  /// one or more '_' characters.
+  String suffix;
+
+  /// Returns a identifier name, which is ideally unique and valid.
+  @override
+  String get name {
+    // Omit root directory from the name if it is either asset or assets.
+    // TODO(bramp): Maybe move this into the _flatStyleDefinition
+    var p = path.replaceFirst(RegExp(r'^asset(s)?[/\\]'), '');
+    if (justBasename) {
+      p = basename(p);
+    }
+    if (!needExtension) {
+      p = withoutExtension(p);
+    }
+
+    return style(convertToIdentifier(p)) + suffix;
+  }
+
+  @override
+  String toString() {
+    return 'UniqueAssetType{'
+        'rootPath: $rootPath, '
+        'path: $path, '
+        'style: $style, '
+        'needExtension: $needExtension, '
+        'suffix: $suffix}';
+  }
 }
 
 extension AssetTypeIterable on Iterable<AssetType> {
-  Iterable<AssetTypeIsUniqueWithoutExtension> mapToIsUniqueWithoutExtension() {
-    return groupBy((e) => p.withoutExtension(e.path))
-        .values
-        .map(
-          (list) => list.map(
-            (e) => AssetTypeIsUniqueWithoutExtension(
-              assetType: e,
-              isUniqueWithoutExtension: list.length == 1,
-            ),
-          ),
-        )
-        .flatten();
+  /// Takes a Iterable<AssetType> and mutates the AssetType's to ensure each
+  /// AssetType has a unique name.
+  ///
+  /// The strategy is as follows:
+  ///
+  /// 1) Convert the asset file name, to a valid dart identifier, that is
+  ///  - Replace non ASCII chars with ASCII.
+  ///  - Ensure the name starts with a letter (not number or _).
+  ///  - Style the name per the camelCase or snakeCase rules.
+  /// 2) Use the asset name without extension. If unique and not a dart reserved
+  ///    word use that.
+  /// 3) Use the asset name with extension. If unique and not a dart reserved
+  ///    word use that.
+  /// 4) If there are any collisions, append a underscore suffix to each item
+  ///    until they are unique.
+  ///
+  /// Because the name change can cause it to clash with an existing name, the
+  /// code is run iteratively until no collision are found. This can be a little
+  /// more expensive, but it simplier.
+  ///
+  Iterable<UniqueAssetType> mapToUniqueAssetType(
+    String Function(String) style, {
+    bool justBasename = false,
+  }) {
+    List<UniqueAssetType> assets = map((e) => UniqueAssetType(
+          assetType: e,
+          style: style,
+          needExtension: false,
+          suffix: '',
+          justBasename: justBasename,
+        )).toList();
+
+    while (true) {
+      // Check if we have any name collisions.
+      final dups = assets.groupBy((e) => e.name).values;
+
+      // No more duplicates, so we can bail.
+      if (dups.every((list) => list.length == 1)) break;
+
+      // Otherwise start to process the list and mutate the assets as needed.
+      assets = dups
+          .map((list) {
+            assert(list.isNotEmpty,
+                'The groupBy list of assets should not be empty.');
+
+            // Check the first element in the list. Since we grouped by each
+            // list element should have the same name.
+            final name = list[0].name;
+            final isValidIdentifer = isValidVariableIdentifier(name);
+
+            // TODO(bramp): In future we should also check this name doesn't collide
+            // with the integration's class name (e.g AssetGenImage).
+
+            // No colissions for this name, carry on.
+            if (list.length == 1 && isValidIdentifer) {
+              return list;
+            }
+
+            // We haven't added filename extensions yet, let's try that first
+            if (!list.every((e) => e.needExtension)) {
+              for (final e in list) {
+                e.needExtension = true;
+              }
+
+              return list;
+            }
+
+            // Ok, we must resolve the conflicts by adding suffixes.
+            var suffix = '';
+            list.forEachIndexed((asset, index) {
+              // Shouldn't need to mutate the first item (unless it's an invalid
+              // identifer).
+              if (index == 0 && isValidIdentifer) return;
+
+              // Append a extra suffixes to each item so they hopefully become unique
+              suffix = '${suffix}_';
+              asset.suffix += suffix;
+            });
+
+            return list;
+          })
+          .flatten()
+          .toList();
+    }
+
+    assert(assets.map((e) => e.name).distinct().length == assets.length,
+        'There are duplicate names in the asset list.');
+
+    return assets;
   }
 }

--- a/packages/core/lib/settings/asset_type.dart
+++ b/packages/core/lib/settings/asset_type.dart
@@ -65,7 +65,7 @@ class UniqueAssetType extends AssetType {
   UniqueAssetType({
     required AssetType assetType,
     this.style = camelCase,
-    this.justBasename = false,
+    this.basenameOnly = false,
     this.needExtension = false,
     this.suffix = '',
   }) : super(rootPath: assetType.rootPath, path: assetType.path);
@@ -76,7 +76,7 @@ class UniqueAssetType extends AssetType {
 
   /// Include just the basename of the asset in the [name],
   /// e.g. 'images/image.png' -> 'image'.
-  final bool justBasename;
+  final bool basenameOnly;
 
   /// Include the extension in the [name], e.g. 'image.png' -> 'imagePng'.
   bool needExtension;
@@ -90,8 +90,8 @@ class UniqueAssetType extends AssetType {
   String get name {
     // Omit root directory from the name if it is either asset or assets.
     // TODO(bramp): Maybe move this into the _flatStyleDefinition
-    var p = path.replaceFirst(RegExp(r'^asset(s)?[/\\]'), '');
-    if (justBasename) {
+    String p = path.replaceFirst(RegExp(r'^asset(s)?[/\\]'), '');
+    if (basenameOnly) {
       p = basename(p);
     }
     if (!needExtension) {
@@ -142,7 +142,7 @@ extension AssetTypeIterable on Iterable<AssetType> {
           style: style,
           needExtension: false,
           suffix: '',
-          justBasename: justBasename,
+          basenameOnly: justBasename,
         )).toList();
 
     while (true) {
@@ -181,7 +181,7 @@ extension AssetTypeIterable on Iterable<AssetType> {
             }
 
             // Ok, we must resolve the conflicts by adding suffixes.
-            var suffix = '';
+            String suffix = '';
             list.forEachIndexed((asset, index) {
               // Shouldn't need to mutate the first item (unless it's an invalid
               // identifer).

--- a/packages/core/lib/utils/identifer.dart
+++ b/packages/core/lib/utils/identifer.dart
@@ -1,0 +1,119 @@
+/// Functions to deal with dart identifiers.
+///
+/// Including keywords from https://dart.dev/language/keywords which are split
+/// into 4 categories:
+///
+/// 1. Contextual keywords, which have meaning only in specific places.
+/// 2. Built-in identifiers.
+/// 3. Limited reserved words.
+/// 4. Reserved words, which can’t be identifiers.
+///
+library identifer;
+
+// 1. Contextual keywords, which have meaning only in specific places. They’re
+// valid identifiers everywhere.
+const contextualKeywords = <String>{'async', 'hide', 'on', 'show', 'sync'};
+
+// 2. Built-in identifiers. These keywords are valid identifiers in most
+// places, but they can’t be used as class or type names, or as import
+// prefixes.
+const builtinKeywords = <String>{
+  'abstract',
+  'as',
+  'base',
+  'covariant',
+  'deferred',
+  'dynamic',
+  'export',
+  'extension',
+  'external',
+  'factory',
+  'Function',
+  'get',
+  'implements',
+  'import',
+  'interface',
+  'late',
+  'library',
+  'mixin',
+  'operator',
+  'part',
+  'required',
+  'sealed',
+  'set',
+  'static',
+  'typedef'
+};
+
+// 3. Limited reserved words. Can’t use as an identifier in any function body
+const asynchronyKeywords = <String>{'await', 'yield'};
+
+// 4. Reserved words, which can’t be identifiers.
+const reservedKeywords = <String>{
+  'assert',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'default',
+  'do',
+  'else',
+  'enum',
+  'extends',
+  'false',
+  'final',
+  'finally',
+  'for',
+  'if',
+  'in',
+  'is',
+  'new',
+  'null',
+  'rethrow',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'var',
+  'void',
+  'when',
+  'while',
+  'with'
+};
+
+/// List of keywords that can't be used as identifiers.
+const invalidIdentifiers = <String>{...asynchronyKeywords, ...reservedKeywords};
+
+/// Returns true this is a valid variable name, that is, a dart identifier which
+/// is not a reserved keyword.
+///
+/// Identifiers can start with a letter or underscore (_), followed by any
+/// combination of those characters plus digits.
+///
+/// See https://dart.dev/language
+bool isValidVariableIdentifier(String identifer) =>
+    !invalidIdentifiers.contains(identifer) && isValidIdentifier(identifer);
+
+/// Returns true if this identifier is valid.
+bool isValidIdentifier(String identifer) =>
+    RegExp(r'^[A-Za-z_][A-Za-z0-9_]*$').hasMatch(identifer);
+
+/// Converts a string to a valid dart identifier. For example, by replacing
+/// invalid characters, and ensuring the string is prefixed with a letter or
+/// underscore.
+String convertToIdentifier(String identifer, {String prefix = 'a'}) {
+  assert(isValidIdentifier(prefix));
+
+  // The current implementation is a bit naive, but it works for now.
+  // Consider replacing with a dart port of https://github.com/avian2/unidecode
+  identifer = identifer.replaceAll(RegExp(r'[^A-Za-z0-9_]'), '_');
+  if (!identifer.startsWith(RegExp(r'[A-Za-z]'))) {
+    identifer = '$prefix$identifer';
+  }
+  return identifer;
+}

--- a/packages/core/lib/utils/string.dart
+++ b/packages/core/lib/utils/string.dart
@@ -14,6 +14,9 @@ extension StringExt on String {
   }
 }
 
+String camelCase(String s) => s.camelCase();
+String snakeCase(String s) => s.snakeCase();
+
 List<String> _intoWords(String path) {
   const symbols = [
     ' ',


### PR DESCRIPTION
## What does this change?

Changed `AssetTypeIsUniqueWithoutExtension` to more robustly pick valid unique names for each asset.

The strategy is as follows:

    1) Convert the asset file name, to a valid dart identifier, that is
       - Replace non ASCII chars with ASCII.
       - Ensure the name starts with a letter (not number or _).
       - Style the name per the camelCase or snakeCase rules.
    2) Use the asset name without extension. If unique and not a dart reserved word use that.
    3) Use the asset name with extension. If unique and not a dart reserved word use that.
    4) If there are any collisions, append a underscore suffix to each item until they are unique.

This will now handle a wide-range of names that weren't previously supported. Dart identifiers, assets starting with numbers, asserts with non-ascii characters, assets with conflicting names (e.g 'a.png' and 'A.png'). See the tests in `packages/core/test/assets_gen_test.dart`.

Fixes #250, #346, and #420 🎯. Happy to discuss on #420.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [X Ensure the tests (`melos run test`)
  - [X] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [X] Appropriate docs were updated (if necessary)
