### PR TITLE
Update PULL_REQUEST_TEMPLATE.md to fix melos command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,6 @@ Please delete options that are not relevant.
 Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
 
 - [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
-  - [ ] Ensure the tests (`melos run unit:test`)
+  - [ ] Ensure the tests (`melos run test`)
   - [ ] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
 - [ ] Appropriate docs were updated (if necessary)


### PR DESCRIPTION
## What does this change?

Minor tweak to PULL_REQUEST_TEMPLATE to fix melos command. The old command doesn't exist, and this one seems to do what was intended.

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run unit:test`)
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
