### PR TITLE
Allowed the generated `values` statement to optionally be static. Fixes #415

### DIFF
--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -453,7 +453,6 @@ String _dotDelimiterStyleAssetsClassDefinition(
 
 String _assetValuesDefinition(
   List<_Statement> statements, {
-  /// Should the values definition be static
   bool static = false,
 }) {
   final values = statements.where((element) => !element.isDirectory);

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -459,13 +459,9 @@ String _assetValuesDefinition(
   final values = statements.where((element) => !element.isDirectory);
   if (values.isEmpty) return '';
   final names = values.map((value) => value.name).join(', ');
-  var type = values.first.type;
-  for (final value in values) {
-    if (type != value.type) {
-      type = 'dynamic';
-      break;
-    }
-  }
+  final type = values.every((element) => element.type == values.first.type)
+      ? values.first.type
+      : 'dynamic';
 
   return '''
   /// List of all assets

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -435,7 +435,9 @@ String _flatStyleAssetsClassDefinition(
       statements.map((statement) => '''${statement.toDartDocString()}
            ${statement.toStaticFieldString()}
            ''').join('\n');
-  return _assetsClassDefinition(className, statements, statementsBlock);
+  final valuesBlock = _assetValuesDefinition(statements, static: true);
+  return _assetsClassDefinition(
+      className, statements, statementsBlock, valuesBlock);
 }
 
 String _dotDelimiterStyleAssetsClassDefinition(
@@ -444,10 +446,16 @@ String _dotDelimiterStyleAssetsClassDefinition(
 ) {
   final statementsBlock =
       statements.map((statement) => statement.toStaticFieldString()).join('\n');
-  return _assetsClassDefinition(className, statements, statementsBlock);
+  final valuesBlock = _assetValuesDefinition(statements, static: true);
+  return _assetsClassDefinition(
+      className, statements, statementsBlock, valuesBlock);
 }
 
-String _assetValuesDefinition(List<_Statement> statements) {
+String _assetValuesDefinition(
+  List<_Statement> statements, {
+  /// Should the values definition be static
+  bool static = false,
+}) {
   final values = statements.where((element) => !element.isDirectory);
   if (values.isEmpty) return '';
   final names = values.map((value) => value.name).join(', ');
@@ -461,15 +469,15 @@ String _assetValuesDefinition(List<_Statement> statements) {
 
   return '''
   /// List of all assets
-  List<$type> get values => [$names];''';
+  ${static ? 'static ' : ''}List<$type> get values => [$names];''';
 }
 
 String _assetsClassDefinition(
   String className,
   List<_Statement> statements,
   String statementsBlock,
+  String valuesBlock,
 ) {
-  final valuesBlock = _assetValuesDefinition(statements);
   return '''
 class $className {
   $className._();

--- a/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
@@ -63,7 +63,7 @@ class Assets {
       AssetGenImage('pictures/chip5.jpg');
 
   /// List of all assets
-  List<dynamic> get values => [
+  static List<dynamic> get values => [
         imagesChip1,
         imagesChip2,
         imagesChip3Chip3,

--- a/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
@@ -64,7 +64,7 @@ class Assets {
       AssetGenImage('pictures/chip5.jpg');
 
   /// List of all assets
-  List<dynamic> get values => [
+  static List<dynamic> get values => [
         images_chip1,
         images_chip2,
         images_chip3_chip3,


### PR DESCRIPTION
## What does this change?

Allowed the generated values statement to optionally be static. For flat listings, each asset is `static` but the `values` property is not, making it inaccessible. Now when generating flat listings, values is static like all the other assets.

Fixes #415 🎯

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [X] Ensure the tests (`melos run unit:test`)
  - [X] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
