### PR TITLE
fix: provide theme to SvgAssetLoader instead of SvgPicture

### DIFF
--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -3,18 +3,18 @@
 ///  FlutterGen
 /// *****************************************************
 
-import 'package:flare_flutter/flare_actor.dart';
-import 'package:flare_flutter/flare_controller.dart';
-import 'package:flutter/services.dart';
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
 
 import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:lottie/lottie.dart';
-import 'package:rive/rive.dart';
 import 'package:vector_graphics/vector_graphics.dart';
+import 'package:flare_flutter/flare_actor.dart';
+import 'package:flare_flutter/flare_controller.dart';
+import 'package:rive/rive.dart';
+import 'package:lottie/lottie.dart';
 
 class $AssetsFlareGen {
   const $AssetsFlareGen();

--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -3,18 +3,18 @@
 ///  FlutterGen
 /// *****************************************************
 
+import 'package:flare_flutter/flare_actor.dart';
+import 'package:flare_flutter/flare_controller.dart';
+import 'package:flutter/services.dart';
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:vector_graphics/vector_graphics.dart';
-import 'package:flare_flutter/flare_actor.dart';
-import 'package:flare_flutter/flare_controller.dart';
-import 'package:rive/rive.dart';
 import 'package:lottie/lottie.dart';
+import 'package:rive/rive.dart';
+import 'package:vector_graphics/vector_graphics.dart';
 
 class $AssetsFlareGen {
   const $AssetsFlareGen();
@@ -318,7 +318,7 @@ class SvgGenImage {
           ? AssetBytesLoader(_assetName,
               assetBundle: bundle, packageName: package)
           : SvgAssetLoader(_assetName,
-              assetBundle: bundle, packageName: package),
+              assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -329,7 +329,6 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -3,18 +3,18 @@
 ///  FlutterGen
 /// *****************************************************
 
-import 'package:flare_flutter/flare_actor.dart';
-import 'package:flare_flutter/flare_controller.dart';
-import 'package:flutter/services.dart';
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
 
 import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:lottie/lottie.dart';
-import 'package:rive/rive.dart';
 import 'package:vector_graphics/vector_graphics.dart';
+import 'package:flare_flutter/flare_actor.dart';
+import 'package:flare_flutter/flare_controller.dart';
+import 'package:rive/rive.dart';
+import 'package:lottie/lottie.dart';
 
 class $AssetsImagesGen {
   const $AssetsImagesGen();

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -3,18 +3,18 @@
 ///  FlutterGen
 /// *****************************************************
 
+import 'package:flare_flutter/flare_actor.dart';
+import 'package:flare_flutter/flare_controller.dart';
+import 'package:flutter/services.dart';
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:vector_graphics/vector_graphics.dart';
-import 'package:flare_flutter/flare_actor.dart';
-import 'package:flare_flutter/flare_controller.dart';
-import 'package:rive/rive.dart';
 import 'package:lottie/lottie.dart';
+import 'package:rive/rive.dart';
+import 'package:vector_graphics/vector_graphics.dart';
 
 class $AssetsImagesGen {
   const $AssetsImagesGen();
@@ -186,7 +186,7 @@ class SvgGenImage {
           ? AssetBytesLoader(_assetName,
               assetBundle: bundle, packageName: package)
           : SvgAssetLoader(_assetName,
-              assetBundle: bundle, packageName: package),
+              assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -197,7 +197,6 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,

--- a/packages/core/lib/generators/integrations/svg_integration.dart
+++ b/packages/core/lib/generators/integrations/svg_integration.dart
@@ -62,7 +62,7 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
     return SvgPicture(
       _isVecFormat ? 
         AssetBytesLoader(_assetName, assetBundle: bundle, packageName: package) :
-        SvgAssetLoader(_assetName, assetBundle: bundle, packageName: package),
+        SvgAssetLoader(_assetName, assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -73,7 +73,6 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ?? (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/lib/settings/pubspec.g.dart
+++ b/packages/core/lib/settings/pubspec.g.dart
@@ -80,7 +80,7 @@ FlutterGen _$FlutterGenFromJson(Map json) => $checkedCreate(
         );
         final val = FlutterGen(
           output: $checkedConvert('output', (v) => v as String),
-          lineLength: $checkedConvert('line_length', (v) => (v as num).toInt()),
+          lineLength: $checkedConvert('line_length', (v) => v as int),
           parseMetadata: $checkedConvert('parse_metadata', (v) => v as bool),
           assets: $checkedConvert(
               'assets', (v) => FlutterGenAssets.fromJson(v as Map)),

--- a/packages/core/lib/settings/pubspec.g.dart
+++ b/packages/core/lib/settings/pubspec.g.dart
@@ -80,7 +80,7 @@ FlutterGen _$FlutterGenFromJson(Map json) => $checkedCreate(
         );
         final val = FlutterGen(
           output: $checkedConvert('output', (v) => v as String),
-          lineLength: $checkedConvert('line_length', (v) => v as int),
+          lineLength: $checkedConvert('line_length', (v) => (v as num).toInt()),
           parseMetadata: $checkedConvert('parse_metadata', (v) => v as bool),
           assets: $checkedConvert(
               'assets', (v) => FlutterGenAssets.fromJson(v as Map)),

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -276,7 +276,7 @@ class SvgGenImage {
           ? AssetBytesLoader(_assetName,
               assetBundle: bundle, packageName: package)
           : SvgAssetLoader(_assetName,
-              assetBundle: bundle, packageName: package),
+              assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -287,7 +287,6 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,

--- a/packages/core/test_resources/actual_data/assets_directory_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_directory_path.gen.dart
@@ -194,7 +194,7 @@ class SvgGenImage {
           ? AssetBytesLoader(_assetName,
               assetBundle: bundle, packageName: package)
           : SvgAssetLoader(_assetName,
-              assetBundle: bundle, packageName: package),
+              assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -205,7 +205,6 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -192,7 +192,7 @@ class SvgGenImage {
           ? AssetBytesLoader(_assetName,
               assetBundle: bundle, packageName: package)
           : SvgAssetLoader(_assetName,
-              assetBundle: bundle, packageName: package),
+              assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -203,7 +203,6 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,

--- a/packages/core/test_resources/actual_data/assets_parse_metadata.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_parse_metadata.gen.dart
@@ -285,7 +285,7 @@ class SvgGenImage {
           ? AssetBytesLoader(_assetName,
               assetBundle: bundle, packageName: package)
           : SvgAssetLoader(_assetName,
-              assetBundle: bundle, packageName: package),
+              assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -296,7 +296,6 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,

--- a/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_svg_integrations.gen.dart
@@ -81,7 +81,7 @@ class SvgGenImage {
           ? AssetBytesLoader(_assetName,
               assetBundle: bundle, packageName: package)
           : SvgAssetLoader(_assetName,
-              assetBundle: bundle, packageName: package),
+              assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -92,7 +92,6 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,

--- a/packages/runner/example/lib/gen/assets.gen.dart
+++ b/packages/runner/example/lib/gen/assets.gen.dart
@@ -3,8 +3,6 @@
 ///  FlutterGen
 /// *****************************************************
 
-import 'package:flare_flutter/flare_actor.dart';
-import 'package:flare_flutter/flare_controller.dart';
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
@@ -12,9 +10,11 @@ import 'package:flare_flutter/flare_controller.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:lottie/lottie.dart';
-import 'package:rive/rive.dart';
 import 'package:vector_graphics/vector_graphics.dart';
+import 'package:flare_flutter/flare_actor.dart';
+import 'package:flare_flutter/flare_controller.dart';
+import 'package:rive/rive.dart';
+import 'package:lottie/lottie.dart';
 
 class $AssetsFlareGen {
   const $AssetsFlareGen();

--- a/packages/runner/example/lib/gen/assets.gen.dart
+++ b/packages/runner/example/lib/gen/assets.gen.dart
@@ -3,6 +3,8 @@
 ///  FlutterGen
 /// *****************************************************
 
+import 'package:flare_flutter/flare_actor.dart';
+import 'package:flare_flutter/flare_controller.dart';
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
@@ -10,11 +12,9 @@
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:vector_graphics/vector_graphics.dart';
-import 'package:flare_flutter/flare_actor.dart';
-import 'package:flare_flutter/flare_controller.dart';
-import 'package:rive/rive.dart';
 import 'package:lottie/lottie.dart';
+import 'package:rive/rive.dart';
+import 'package:vector_graphics/vector_graphics.dart';
 
 class $AssetsFlareGen {
   const $AssetsFlareGen();
@@ -293,7 +293,7 @@ class SvgGenImage {
           ? AssetBytesLoader(_assetName,
               assetBundle: bundle, packageName: package)
           : SvgAssetLoader(_assetName,
-              assetBundle: bundle, packageName: package),
+              assetBundle: bundle, packageName: package, theme: theme),
       key: key,
       matchTextDirection: matchTextDirection,
       width: width,
@@ -304,7 +304,6 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      theme: theme,
       colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,


### PR DESCRIPTION
## What does this change?
Since version 5.5.0+1, the SvgTheme no longer works. It doesn't work because flutter_svg has deprecated using the `theme` with the `SvgPicture` constructor, and suggests that you pass the theme to the bytes loader instead.

Fixes #531  🎯

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run test`)
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [x] Appropriate docs were updated (if necessary)
