### PR TITLE
chore: fix concurrency execute with melos.

### DIFF
--- a/examples/example/test/svg_integrations_test.dart
+++ b/examples/example/test/svg_integrations_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'package:example/gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';

--- a/melos.yaml
+++ b/melos.yaml
@@ -8,6 +8,7 @@ packages:
 ide:
   intellij:
     enabled: true
+    moduleNamePrefix: ''
 
 command:
   clean:
@@ -74,7 +75,7 @@ scripts:
 
   test:
     run: |
-      melos test:dart --no-select && \
+      melos test:dart --no-select
       melos test:flutter --no-select
     description: dart & flutter test
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -8,29 +8,31 @@ packages:
 ide:
   intellij:
     enabled: true
-    moduleNamePrefix: ''
-  vscode: true
 
 command:
   clean:
     hooks:
       post:
-        run: |
-          melos exec -c 6 -- flutter clean
+        run: flutter clean
+        exec:
+          concurrency: 1
         description: flutter clean
 
 scripts:
   get:
-    run: |
-      melos exec -c 6 -- flutter pub get
+    run: flutter pub get
+    exec:
+      concurrency: 1
     description: flutter pub get
 
   upgrade:
-    run: melos exec -c 6 -- flutter pub upgrade
+    run: flutter pub upgrade
+    exec:
+      concurrency: 1
     description: flutter pub upgrade
 
   analyze:
-    run: melos exec -c 6 -- flutter analyze
+    exec: flutter analyze
     description: flutter analyze
 
   format:
@@ -53,23 +55,27 @@ scripts:
     description: dart run build_runner build --delete-conflicting-outputs
 
   gen:examples:command:
-    exec: dart ../../packages/command/bin/flutter_gen_command.dart --config pubspec.yaml
+    exec: dart ../../packages/command/bin/flutter_gen_command.dart
     packageFilters:
-      scope: 
+      scope:
         - example
         - example_resources
-    description: dart ../../packages/command/bin/flutter_gen_command.dart --config pubspec.yaml
+    description: dart ../../packages/command/bin/flutter_gen_command.dart
 
   gen:examples:build_runner:
-    exec: flutter pub run build_runner build --delete-conflicting-outputs
+    run: flutter pub run build_runner build --delete-conflicting-outputs
+    exec:
+      concurrency: 1
     packageFilters:
-      scope: 
+      scope:
         - example
         - example_resources
     description: flutter pub run build_runner build --delete-conflicting-outputs
 
   test:
-    run: melos test:dart --no-select && melos test:flutter --no-select
+    run: |
+      melos test:dart --no-select && \
+      melos test:flutter --no-select
     description: dart & flutter test
 
   test:dart:

--- a/packages/core/test/assets_gen_integrations_test.dart
+++ b/packages/core/test/assets_gen_integrations_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'package:flutter_gen_core/generators/integrations/flare_integration.dart';
 import 'package:flutter_gen_core/generators/integrations/integration.dart';
 import 'package:flutter_gen_core/generators/integrations/lottie_integration.dart';

--- a/packages/core/test/assets_gen_test.dart
+++ b/packages/core/test/assets_gen_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';

--- a/packages/core/test/colors_gen_test.dart
+++ b/packages/core/test/colors_gen_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';

--- a/packages/core/test/flutter_gen_test.dart
+++ b/packages/core/test/flutter_gen_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'dart:io';
 
 import 'package:flutter_gen_core/flutter_generator.dart';

--- a/packages/core/test/fonts_gen_test.dart
+++ b/packages/core/test/fonts_gen_test.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';

--- a/packages/core/test/gen_test_helper.dart
+++ b/packages/core/test/gen_test_helper.dart
@@ -1,4 +1,3 @@
-@TestOn('vm')
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';


### PR DESCRIPTION
## What does this change?

I limited concurrent execution because these logs were being output during the execution of the flutter command.

When `melos run get`
```
ERROR: ERROR: [example]: Waiting for another flutter command to release the startup lock...
ERROR: ERROR: [flutter_gen]: Waiting for another flutter command to release the startup lock...
ERROR: ERROR: [flutter_gen_runner]: Waiting for another flutter command to release the startup lock...
```

And fix analyze.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run test`)
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [ ] Appropriate docs were updated (if necessary)
