### PR TITLE
⚡️ Enables `gaplessPlayback` by default for image assets

### DIFF
--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -247,7 +247,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -94,7 +94,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     @Deprecated('Do not specify package for a generated library asset')
     String? package = package,

--- a/packages/command/example/lib/gen/assets.gen.dart
+++ b/packages/command/example/lib/gen/assets.gen.dart
@@ -217,7 +217,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/example/lib/gen/assets.gen.dart
+++ b/packages/core/example/lib/gen/assets.gen.dart
@@ -215,7 +215,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/lib/generators/integrations/image_integration.dart
+++ b/packages/core/lib/generators/integrations/image_integration.dart
@@ -57,7 +57,7 @@ ${isPackage ? "\n  static const String package = '$packageName';" : ''}
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     ${isPackage ? deprecationMessagePackage : ''}
     String? package$packageParameter,

--- a/packages/core/test_resources/actual_data/assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets.gen.dart
@@ -189,7 +189,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_camel_case.gen.dart
@@ -111,7 +111,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/test_resources/actual_data/assets_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_change_class_name.gen.dart
@@ -70,7 +70,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/test_resources/actual_data/assets_directory_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_directory_path.gen.dart
@@ -107,7 +107,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/test_resources/actual_data/assets_flavored.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_flavored.gen.dart
@@ -191,7 +191,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_no_integrations.gen.dart
@@ -145,7 +145,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/test_resources/actual_data/assets_package_exclude_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_exclude_files.gen.dart
@@ -100,7 +100,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter.gen.dart
@@ -100,7 +100,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     @Deprecated('Do not specify package for a generated library asset')
     String? package = package,

--- a/packages/core/test_resources/actual_data/assets_parse_metadata.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_parse_metadata.gen.dart
@@ -198,7 +198,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_snake_case.gen.dart
@@ -112,7 +112,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,

--- a/packages/runner/example/lib/gen/assets.gen.dart
+++ b/packages/runner/example/lib/gen/assets.gen.dart
@@ -218,7 +218,7 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
     FilterQuality filterQuality = FilterQuality.low,


### PR DESCRIPTION
## What does this change?

Image assets are finalized during builds, they cannot be changed during the runtime. The `gaplessPlayback` defaults to `false` which might lead to images flashing between routes when the provider changes, which it doesn't in fact.

Now we change it to `true` to ignore changes to provide a good display experience. This can also considered as a non-breaking change in most cases.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
