### PR TITLE
fix: Avoid properties added in dart_style v2.3.7

### DIFF
--- a/packages/core/lib/flutter_generator.dart
+++ b/packages/core/lib/flutter_generator.dart
@@ -34,7 +34,6 @@ class FlutterGenerator {
     final output = config.pubspec.flutterGen.output;
     final lineLength = config.pubspec.flutterGen.lineLength;
     final formatter = DartFormatter(
-      languageVersion: DartFormatter.latestLanguageVersion,
       pageWidth: lineLength,
       lineEnding: '\n',
     );

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   json_annotation: ^4.4.0
   glob: ^2.0.0
 
-  dart_style: '>=2.2.4 <4.0.0'
+  dart_style: '>=2.2.4 <3.0.0'
   archive: '>=3.4.0 <5.0.0'
   args: ^2.0.0
   pub_semver: ^2.0.0

--- a/packages/core/test/assets_gen_test.dart
+++ b/packages/core/test/assets_gen_test.dart
@@ -60,7 +60,6 @@ void main() {
       final pubspec = File('test_resources/pubspec_assets_no_list.yaml');
       final config = loadPubspecConfig(pubspec);
       final formatter = DartFormatter(
-        languageVersion: dartFormatterLanguageVersion,
         pageWidth: config.pubspec.flutterGen.lineLength,
         lineEnding: '\n',
       );

--- a/packages/core/test/colors_gen_test.dart
+++ b/packages/core/test/colors_gen_test.dart
@@ -23,7 +23,6 @@ void main() {
       final pubspec = File('test_resources/pubspec_colors_no_inputs.yaml');
       final config = loadPubspecConfig(pubspec);
       final formatter = DartFormatter(
-        languageVersion: dartFormatterLanguageVersion,
         pageWidth: config.pubspec.flutterGen.lineLength,
         lineEnding: '\n',
       );
@@ -42,7 +41,6 @@ void main() {
       final pubspec = File('test_resources/pubspec_colors_no_inputs_list.yaml');
       final config = loadPubspecConfig(pubspec);
       final formatter = DartFormatter(
-        languageVersion: dartFormatterLanguageVersion,
         pageWidth: config.pubspec.flutterGen.lineLength,
         lineEnding: '\n',
       );

--- a/packages/core/test/fonts_gen_test.dart
+++ b/packages/core/test/fonts_gen_test.dart
@@ -23,7 +23,6 @@ void main() {
         File('test_resources/pubspec_fonts_no_family.yaml'),
       );
       final formatter = DartFormatter(
-        languageVersion: dartFormatterLanguageVersion,
         pageWidth: config.pubspec.flutterGen.lineLength,
         lineEnding: '\n',
       );

--- a/packages/core/test/gen_test_helper.dart
+++ b/packages/core/test/gen_test_helper.dart
@@ -9,8 +9,6 @@ import 'package:flutter_gen_core/settings/config.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
-final dartFormatterLanguageVersion = DartFormatter.latestLanguageVersion;
-
 Future<void> clearTestResults() async {}
 
 Future<List<String>> runAssetsGen(
@@ -36,7 +34,6 @@ Future<List<String>> runAssetsGen(
   stdout.writeln('[DEBUG] test: Generate from API...');
   final config = loadPubspecConfig(pubspecFile, buildFile: buildFile);
   final formatter = DartFormatter(
-    languageVersion: dartFormatterLanguageVersion,
     pageWidth: config.pubspec.flutterGen.lineLength,
     lineEnding: '\n',
   );
@@ -80,7 +77,6 @@ Future<List<String>> runColorsGen(
   final pubspecFile = File(pubspec);
   final config = loadPubspecConfig(pubspecFile);
   final formatter = DartFormatter(
-    languageVersion: dartFormatterLanguageVersion,
     pageWidth: config.pubspec.flutterGen.lineLength,
     lineEnding: '\n',
   );
@@ -124,7 +120,6 @@ Future<List<String>> runFontsGen(
   final pubspecFile = File(pubspec);
   final config = loadPubspecConfig(pubspecFile);
   final formatter = DartFormatter(
-    languageVersion: dartFormatterLanguageVersion,
     pageWidth: config.pubspec.flutterGen.lineLength,
     lineEnding: '\n',
   );


### PR DESCRIPTION
## What does this change?

Removed `DartFormatter.latestLanguageVersion` and modified it to work with dart_style 2.2.4.

Fixes #651 🎯

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run test`)
  - [x] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [ ] Appropriate docs were updated (if necessary)
