### PR TITLE
⬆️ Constraint `dart_style` v3 which also bumps the SDK constraint to 3.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,5 +61,5 @@ jobs:
 
       - name: Check for any formatting and statically analyze the code.
         run: |
-          melos format
+          melos run format
           melos analyze

--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -107,7 +107,7 @@ class $AssetsLottieGen {
         cat,
         geometricalAnimation,
         hamburgerArrow,
-        spinningCarrousel,
+        spinningCarrousel
       ];
 }
 

--- a/examples/example/pubspec.yaml
+++ b/examples/example/pubspec.yaml
@@ -3,8 +3,7 @@ description: A sample project using FlutterGen.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
-  flutter: '>=3.16.0'
+  sdk: ^3.4.0
 
 dependencies:
   flutter:

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -24,7 +24,8 @@ class $AssetsImagesGen {
   SvgGenImage get dart => const SvgGenImage('assets/images/dart.svg');
 
   /// File path: assets/images/favorite.flr
-  String get favorite => 'assets/images/favorite.flr';
+  String get favorite =>
+      'packages/example_resources/assets/images/favorite.flr';
 
   /// File path: assets/images/flutter3.jpg
   AssetGenImage get flutter3 =>
@@ -54,7 +55,7 @@ class $AssetsUnknownGen {
 }
 
 class ResAssets {
-  ResAssets._();
+  const ResAssets._();
 
   static const String package = 'example_resources';
 

--- a/examples/example_resources/pubspec.yaml
+++ b/examples/example_resources/pubspec.yaml
@@ -3,8 +3,7 @@ description: A sample project using FlutterGen.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
-  flutter: '>=3.16.0'
+  sdk: ^3.4.0
 
 dependencies:
   flutter:

--- a/melos.yaml
+++ b/melos.yaml
@@ -28,10 +28,6 @@ scripts:
       flutter: false
     description: dart pub upgrade
 
-  analyze:
-    exec: flutter analyze
-    description: flutter analyze
-
   format:
     run: |
       dart format --set-exit-if-changed .

--- a/melos.yaml
+++ b/melos.yaml
@@ -33,8 +33,10 @@ scripts:
     description: flutter analyze
 
   format:
-    run: dart format --set-exit-if-changed .
-    description: dart format --set-exit-if-changed .
+    run: |
+      dart format --set-exit-if-changed .
+      git --no-pager diff --exit-code
+    description: Format Dart files and exit if unstaged changes exist
 
   build:
     exec: flutter build apk

--- a/packages/command/pubspec.yaml
+++ b/packages/command/pubspec.yaml
@@ -7,7 +7,7 @@ documentation: https://github.com/FlutterGen/flutter_gen
 issue_tracker: https://github.com/FlutterGen/flutter_gen/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.4.0
 
 executables:
   fluttergen: flutter_gen_command

--- a/packages/core/lib/flutter_generator.dart
+++ b/packages/core/lib/flutter_generator.dart
@@ -1,11 +1,11 @@
 import 'dart:io' show stdout, Directory, File;
 
-import 'package:dart_style/dart_style.dart' show DartFormatter;
 import 'package:flutter_gen_core/generators/assets_generator.dart';
 import 'package:flutter_gen_core/generators/colors_generator.dart';
 import 'package:flutter_gen_core/generators/fonts_generator.dart';
 import 'package:flutter_gen_core/settings/config.dart';
 import 'package:flutter_gen_core/utils/file.dart';
+import 'package:flutter_gen_core/utils/formatter.dart';
 import 'package:path/path.dart' show join, normalize;
 
 class FlutterGenerator {
@@ -29,15 +29,10 @@ class FlutterGenerator {
       return;
     }
 
+    final formatter = buildDartFormatterFromConfig(config);
     final flutter = config.pubspec.flutter;
     final flutterGen = config.pubspec.flutterGen;
     final output = config.pubspec.flutterGen.output;
-    final lineLength = config.pubspec.flutterGen.lineLength;
-    final formatter = DartFormatter(
-      languageVersion: DartFormatter.latestLanguageVersion,
-      pageWidth: lineLength,
-      lineEnding: '\n',
-    );
 
     void defaultWriter(String contents, String path) {
       final file = File(path);

--- a/packages/core/lib/settings/config.dart
+++ b/packages/core/lib/settings/config.dart
@@ -86,10 +86,10 @@ Config loadPubspecConfig(File pubspecFile, {File? buildFile}) {
 Config? loadPubspecConfigOrNull(File pubspecFile, {File? buildFile}) {
   try {
     return loadPubspecConfig(pubspecFile, buildFile: buildFile);
-  } on FileSystemException catch (e) {
-    stderr.writeln(e.message);
-  } on InvalidSettingsException catch (e) {
-    stderr.writeln(e.message);
+  } on FileSystemException catch (e, s) {
+    stderr.writeln('$e\n$s');
+  } on InvalidSettingsException catch (e, s) {
+    stderr.writeln('$e\n$s');
   }
   return null;
 }

--- a/packages/core/lib/settings/pubspec.g.dart
+++ b/packages/core/lib/settings/pubspec.g.dart
@@ -16,6 +16,8 @@ Pubspec _$PubspecFromJson(Map json) => $checkedCreate(
         );
         final val = Pubspec(
           packageName: $checkedConvert('name', (v) => v as String),
+          environment: $checkedConvert(
+              'environment', (v) => _environmentFromJson(v as Map?)),
           flutterGen: $checkedConvert(
               'flutter_gen', (v) => FlutterGen.fromJson(v as Map)),
           flutter:

--- a/packages/core/lib/utils/formatter.dart
+++ b/packages/core/lib/utils/formatter.dart
@@ -1,0 +1,20 @@
+import 'package:dart_style/dart_style.dart' show DartFormatter;
+import 'package:pub_semver/pub_semver.dart' show VersionConstraint;
+
+import '../settings/config.dart' show Config;
+
+/// The formatter will only use the tall-style if the SDK constraint is ^3.7.
+DartFormatter buildDartFormatterFromConfig(Config config) {
+  final sdkConstraint = config.pubspec.environment['sdk'];
+  final useShort = switch (sdkConstraint) {
+    final c? => c.allowsAny(VersionConstraint.parse('<3.7.0')),
+    _ => true,
+  };
+  return DartFormatter(
+    languageVersion: useShort
+        ? DartFormatter.latestShortStyleLanguageVersion
+        : DartFormatter.latestLanguageVersion,
+    pageWidth: config.pubspec.flutterGen.lineLength,
+    lineEnding: '\n',
+  );
+}

--- a/packages/core/lib/utils/identifer.dart
+++ b/packages/core/lib/utils/identifer.dart
@@ -7,7 +7,7 @@
 /// 2. Built-in identifiers.
 /// 3. Limited reserved words.
 /// 4. Reserved words, which can’t be identifiers.
-///
+// ignore: unnecessary_library_name
 library identifer;
 
 // 1. Contextual keywords, which have meaning only in specific places. They’re

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -7,7 +7,7 @@ documentation: https://github.com/FlutterGen/flutter_gen
 issue_tracker: https://github.com/FlutterGen/flutter_gen/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.4.0
 
 version_gen:
   path: lib/
@@ -24,7 +24,7 @@ dependencies:
   json_annotation: ^4.4.0
   glob: ^2.0.0
 
-  dart_style: '>=2.3.7 <4.0.0'
+  dart_style: ^3.0.0
   archive: '>=3.4.0 <5.0.0'
   args: ^2.0.0
   pub_semver: ^2.0.0

--- a/packages/core/test/assets_gen_test.dart
+++ b/packages/core/test/assets_gen_test.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 
-import 'package:dart_style/dart_style.dart';
 import 'package:dartx/dartx.dart';
 import 'package:flutter_gen_core/generators/assets_generator.dart';
 import 'package:flutter_gen_core/generators/generator_helper.dart';
 import 'package:flutter_gen_core/settings/asset_type.dart';
 import 'package:flutter_gen_core/settings/config.dart';
 import 'package:flutter_gen_core/utils/error.dart';
+import 'package:flutter_gen_core/utils/formatter.dart';
 import 'package:flutter_gen_core/utils/string.dart';
 import 'package:test/test.dart';
 
@@ -59,11 +59,7 @@ void main() {
     test('Assets with No lists on pubspec.yaml', () async {
       final pubspec = File('test_resources/pubspec_assets_no_list.yaml');
       final config = loadPubspecConfig(pubspec);
-      final formatter = DartFormatter(
-        languageVersion: dartFormatterLanguageVersion,
-        pageWidth: config.pubspec.flutterGen.lineLength,
-        lineEnding: '\n',
-      );
+      final formatter = buildDartFormatterFromConfig(config);
 
       expect(
         () => generateAssets(

--- a/packages/core/test/colors_gen_test.dart
+++ b/packages/core/test/colors_gen_test.dart
@@ -1,10 +1,10 @@
 import 'dart:io';
 
-import 'package:dart_style/dart_style.dart';
 import 'package:flutter_gen_core/generators/colors_generator.dart';
 import 'package:flutter_gen_core/settings/color_path.dart';
 import 'package:flutter_gen_core/settings/config.dart';
 import 'package:flutter_gen_core/utils/error.dart';
+import 'package:flutter_gen_core/utils/formatter.dart';
 import 'package:test/test.dart';
 
 import 'gen_test_helper.dart';
@@ -22,11 +22,7 @@ void main() {
     test('Wrong colors settings on pubspec.yaml', () async {
       final pubspec = File('test_resources/pubspec_colors_no_inputs.yaml');
       final config = loadPubspecConfig(pubspec);
-      final formatter = DartFormatter(
-        languageVersion: dartFormatterLanguageVersion,
-        pageWidth: config.pubspec.flutterGen.lineLength,
-        lineEnding: '\n',
-      );
+      final formatter = buildDartFormatterFromConfig(config);
 
       expect(
         () => generateColors(
@@ -41,11 +37,7 @@ void main() {
     test('Wrong colors settings on pubspec.yaml', () async {
       final pubspec = File('test_resources/pubspec_colors_no_inputs_list.yaml');
       final config = loadPubspecConfig(pubspec);
-      final formatter = DartFormatter(
-        languageVersion: dartFormatterLanguageVersion,
-        pageWidth: config.pubspec.flutterGen.lineLength,
-        lineEnding: '\n',
-      );
+      final formatter = buildDartFormatterFromConfig(config);
 
       expect(
         () {

--- a/packages/core/test/fonts_gen_test.dart
+++ b/packages/core/test/fonts_gen_test.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
-import 'package:dart_style/dart_style.dart';
 import 'package:flutter_gen_core/generators/fonts_generator.dart';
 import 'package:flutter_gen_core/settings/config.dart';
 import 'package:flutter_gen_core/utils/error.dart';
+import 'package:flutter_gen_core/utils/formatter.dart';
 import 'package:test/test.dart';
 
 import 'gen_test_helper.dart';
@@ -22,11 +22,7 @@ void main() {
       final config = loadPubspecConfig(
         File('test_resources/pubspec_fonts_no_family.yaml'),
       );
-      final formatter = DartFormatter(
-        languageVersion: dartFormatterLanguageVersion,
-        pageWidth: config.pubspec.flutterGen.lineLength,
-        lineEnding: '\n',
-      );
+      final formatter = buildDartFormatterFromConfig(config);
 
       expect(
         () => generateFonts(FontsGenConfig.fromConfig(config), formatter),

--- a/packages/core/test/gen_test_helper.dart
+++ b/packages/core/test/gen_test_helper.dart
@@ -1,15 +1,13 @@
 import 'dart:io';
 
-import 'package:dart_style/dart_style.dart';
 import 'package:flutter_gen_core/flutter_generator.dart';
 import 'package:flutter_gen_core/generators/assets_generator.dart';
 import 'package:flutter_gen_core/generators/colors_generator.dart';
 import 'package:flutter_gen_core/generators/fonts_generator.dart';
 import 'package:flutter_gen_core/settings/config.dart';
+import 'package:flutter_gen_core/utils/formatter.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
-
-final dartFormatterLanguageVersion = DartFormatter.latestLanguageVersion;
 
 Future<void> clearTestResults() async {}
 
@@ -35,11 +33,7 @@ Future<List<String>> runAssetsGen(
 
   stdout.writeln('[DEBUG] test: Generate from API...');
   final config = loadPubspecConfig(pubspecFile, buildFile: buildFile);
-  final formatter = DartFormatter(
-    languageVersion: dartFormatterLanguageVersion,
-    pageWidth: config.pubspec.flutterGen.lineLength,
-    lineEnding: '\n',
-  );
+  final formatter = buildDartFormatterFromConfig(config);
 
   final actual = await generateAssets(
     AssetsGenConfig.fromConfig(pubspecFile, config),
@@ -79,11 +73,7 @@ Future<List<String>> runColorsGen(
 
   final pubspecFile = File(pubspec);
   final config = loadPubspecConfig(pubspecFile);
-  final formatter = DartFormatter(
-    languageVersion: dartFormatterLanguageVersion,
-    pageWidth: config.pubspec.flutterGen.lineLength,
-    lineEnding: '\n',
-  );
+  final formatter = buildDartFormatterFromConfig(config);
 
   final actual = generateColors(
     pubspecFile,
@@ -123,11 +113,7 @@ Future<List<String>> runFontsGen(
 
   final pubspecFile = File(pubspec);
   final config = loadPubspecConfig(pubspecFile);
-  final formatter = DartFormatter(
-    languageVersion: dartFormatterLanguageVersion,
-    pageWidth: config.pubspec.flutterGen.lineLength,
-    lineEnding: '\n',
-  );
+  final formatter = buildDartFormatterFromConfig(config);
 
   final actual = generateFonts(
     FontsGenConfig.fromConfig(config),

--- a/packages/runner/lib/flutter_gen_runner.dart
+++ b/packages/runner/lib/flutter_gen_runner.dart
@@ -37,7 +37,7 @@ class FlutterGenBuilder extends Builder {
     if (_config == null) {
       return;
     }
-    final state = await _createState(_config!, buildStep);
+    final state = await _createState(_config, buildStep);
     if (state.shouldSkipGenerate(_currentState)) {
       return;
     }
@@ -56,7 +56,7 @@ class FlutterGenBuilder extends Builder {
     if (_config == null) {
       return {};
     }
-    final output = _config!.pubspec.flutterGen.output;
+    final output = _config.pubspec.flutterGen.output;
     return {
       r'$package$': [
         for (final name in [

--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -7,7 +7,7 @@ documentation: https://github.com/FlutterGen/flutter_gen
 issue_tracker: https://github.com/FlutterGen/flutter_gen/issues
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.4.0
 
 dependencies:
   flutter_gen_core: 5.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gen_repository
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.4.0
 
 dev_dependencies:
   lints: any # Ignoring the version to allow editing across SDK versions.


### PR DESCRIPTION
## What does this change?

Use the `dart_style` v3 to cover the short-style formatting of old projects.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
