### PR TITLE
♻️ Fighting with the Dart formatter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,7 +52,7 @@ body:
 
         flutter_gen:
           output: lib/gen/
-          line_length: 80
+        #  line_length: 80
 
           integrations:
             flutter_svg: true

--- a/.idea/runConfigurations/build_runner_build_example.xml
+++ b/.idea/runConfigurations/build_runner_build_example.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build_runner build -&gt; example" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="arguments" value="build -d" />
+    <option name="filePath" value="$PROJECT_DIR$/examples/example/.dart_tool/build/entrypoint/build.dart" />
+    <option name="workingDirectory" value="$PROJECT_DIR$/examples/example" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/build_runner_build_example_resources.xml
+++ b/.idea/runConfigurations/build_runner_build_example_resources.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build_runner build -&gt; example_resources" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="arguments" value="build -d" />
+    <option name="filePath" value="$PROJECT_DIR$/examples/example_resources/.dart_tool/build/entrypoint/build.dart" />
+    <option name="workingDirectory" value="$PROJECT_DIR$/examples/example_resources" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Default configuration can be found [here](https://github.com/FlutterGen/flutter_
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
+  # line_length: 80 # Optional
 
   # Optional
   integrations:
@@ -184,7 +184,7 @@ targets:
       flutter_gen_runner: # or flutter_gen
         options: 
           output: lib/build_gen/ # Optional (default: lib/gen/)
-          line_length: 120 # Optional (default: 80)
+          line_length: 120 # Optional
 ```
 
 ## Available Parsers

--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/examples/example/lib/gen/colors.gen.dart
+++ b/examples/example/lib/gen/colors.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';

--- a/examples/example/lib/gen/fonts.gen.dart
+++ b/examples/example/lib/gen/fonts.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class MyFontFamily {
   MyFontFamily._();

--- a/examples/example/pubspec.yaml
+++ b/examples/example/pubspec.yaml
@@ -14,15 +14,16 @@ dependencies:
 
   flutter_svg: ^2.0.0
   lottie: ^3.0.0
-  rive: ^0.11.0
+  rive: ^0.13.20
 
 dev_dependencies:
+  lints: any
   flutter_test:
     sdk: flutter
+
   flutter_gen_runner:
     path: ../../packages/runner
 
-  lints: ^2.0.0
   build_runner: ^2.0.0
 
 flutter_gen:

--- a/examples/example/pubspec.yaml
+++ b/examples/example/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
+#  line_length: 80 # Optional
 
   integrations:
     flutter_svg: true

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/examples/example_resources/lib/gen/colors.gen.dart
+++ b/examples/example_resources/lib/gen/colors.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';

--- a/examples/example_resources/pubspec.yaml
+++ b/examples/example_resources/pubspec.yaml
@@ -21,7 +21,6 @@ dev_dependencies:
 
 flutter_gen:
   output: lib/gen/
-  line_length: 80
 
   integrations:
     flutter_svg: true

--- a/examples/example_resources/pubspec.yaml
+++ b/examples/example_resources/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   flutter_svg: ^2.0.0
   lottie: ^3.0.0
-  rive: ^0.11.0
+  rive: ^0.13.20
 
 dev_dependencies:
   flutter_gen_runner:

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -145,6 +145,7 @@ Future<String> generateAssets(
   }
 
   final buffer = StringBuffer();
+  buffer.writeln('// dart format width=${formatter.pageWidth}\n');
   buffer.writeln(header);
   buffer.writeln(ignore);
   buffer.writeln(importsBuffer.toString());

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -84,7 +84,7 @@ Future<String> generateAssets(
   final deprecatedPackageParam =
       config.flutterGen.assets.packageParameterEnabled != null;
   if (deprecatedStyle || deprecatedPackageParam) {
-    final deprecationBuffer = StringBuffer();
+    final deprecationBuffer = StringBuffer('\n');
     if (deprecatedStyle) {
       deprecationBuffer.writeln(
         sBuildDeprecation(

--- a/packages/core/lib/generators/colors_generator.dart
+++ b/packages/core/lib/generators/colors_generator.dart
@@ -24,6 +24,7 @@ String generateColors(
 
   final buffer = StringBuffer();
   final className = colorsConfig.outputs.className;
+  buffer.writeln('// dart format width=${formatter.pageWidth}');
   buffer.writeln(header);
   buffer.writeln(ignore);
   buffer.writeln("import 'package:flutter/painting.dart';");

--- a/packages/core/lib/generators/fonts_generator.dart
+++ b/packages/core/lib/generators/fonts_generator.dart
@@ -45,6 +45,7 @@ String generateFonts(
 
   final buffer = StringBuffer();
   final className = fontsConfig.outputs.className;
+  buffer.writeln('// dart format width=${formatter.pageWidth}');
   buffer.writeln(header);
   buffer.writeln(ignore);
   buffer.writeln('class $className {');

--- a/packages/core/lib/generators/generator_helper.dart
+++ b/packages/core/lib/generators/generator_helper.dart
@@ -10,11 +10,18 @@ String get header {
 ''';
 }
 
+const _ignoredRules = <String>[
+  'deprecated_member_use',
+  'directives_ordering',
+  'implicit_dynamic_list_literal',
+  'unnecessary_import',
+];
+
 String get ignore {
   return '''// coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
-  
+// ignore_for_file: ${_ignoredRules.join(',')}
+
 ''';
 }
 

--- a/packages/core/lib/settings/config.dart
+++ b/packages/core/lib/settings/config.dart
@@ -108,7 +108,7 @@ Config loadPubspecConfig(File pubspecFile, {File? buildFile}) {
   };
   final pubspecLockMap = loadYaml(pubspecLockContent) as YamlMap?;
   if (safeCast<String>(pubspecLockMap?['sdks']?['dart']) case final sdk?) {
-    sdkConstraint = VersionConstraint.parse(sdk);
+    sdkConstraint ??= VersionConstraint.parse(sdk);
   }
 
   final analysisOptionsFile = File(

--- a/packages/core/lib/settings/config.dart
+++ b/packages/core/lib/settings/config.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+// import 'package:collection/collection.dart';
+// import 'package:dart_style/dart_style.dart' show TrailingCommas;
 import 'package:flutter_gen_core/settings/config_default.dart';
 import 'package:flutter_gen_core/settings/pubspec.dart';
 import 'package:flutter_gen_core/utils/cast.dart' show safeCast;
@@ -16,11 +18,18 @@ class Config {
     required this.pubspec,
     required this.pubspecFile,
     required this.sdkConstraint,
+    // required this.formatterTrailingCommas,
+    required this.formatterPageWidth,
   });
 
   final Pubspec pubspec;
   final File pubspecFile;
   final VersionConstraint? sdkConstraint;
+
+  // TODO(ANYONE): Allow passing the trailing commas option after the SDK constraint was bumped to ^3.7.
+  // final TrailingCommas? formatterTrailingCommas;
+
+  final int? formatterPageWidth;
 }
 
 Config loadPubspecConfig(File pubspecFile, {File? buildFile}) {
@@ -102,10 +111,30 @@ Config loadPubspecConfig(File pubspecFile, {File? buildFile}) {
     sdkConstraint = VersionConstraint.parse(sdk);
   }
 
+  final analysisOptionsFile = File(
+    normalize(join(basename(pubspecFile.parent.path), 'analysis_options.yaml')),
+  );
+  final analysisOptionsContent = switch (analysisOptionsFile.existsSync()) {
+    true => analysisOptionsFile.readAsStringSync(),
+    false => '',
+  };
+  final analysisOptionsMap = loadYaml(analysisOptionsContent) as YamlMap?;
+  // final formatterTrailingCommas = switch (safeCast<String>(
+  //   analysisOptionsMap?['formatter']?['trailing_commas'],
+  // )) {
+  //   final s? => TrailingCommas.values.firstWhereOrNull((e) => e.name == s),
+  //   _ => null,
+  // };
+  final formatterPageWidth = safeCast<int>(
+    analysisOptionsMap?['formatter']?['page_width'],
+  );
+
   return Config._(
     pubspec: pubspec,
     pubspecFile: pubspecFile,
     sdkConstraint: sdkConstraint,
+    // formatterTrailingCommas: formatterTrailingCommas,
+    formatterPageWidth: formatterPageWidth,
   );
 }
 

--- a/packages/core/lib/settings/config_default.dart
+++ b/packages/core/lib/settings/config_default.dart
@@ -2,12 +2,9 @@ const configDefaultYamlContent = '''
 name: UNKNOWN
 
 flutter_gen:
-  # Optional
-  output: lib/gen/
-  # Optional
-  line_length: 80
-  # Optional
-  parse_metadata: false
+  output: lib/gen/ # Optional
+#  line_length: 80 # Optional
+  parse_metadata: false # Optional
 
   # Optional
   integrations:
@@ -17,37 +14,28 @@ flutter_gen:
     lottie: false
 
   assets:
-    # Optional
-    enabled: true
-    # Optional
-    outputs:
-      # Optional
+    enabled: true # Optional
+    outputs: # Optional
       # Set to true if you want this package to be a package dependency
       # See: https://flutter.dev/docs/development/ui/assets-and-images#from-packages
-      package_parameter_enabled: false
-      # Optional
+      package_parameter_enabled: false # Optional
       # Available values:
       # - camel-case
       # - snake-case
       # - dot-delimiter
-      style: dot-delimiter
+      style: dot-delimiter # Optional
       class_name: Assets
     exclude: []
 
   fonts:
-    # Optional
-    enabled: true
-    # Optional
-    outputs:
+    enabled: true # Optional
+    outputs: # Optional
       class_name: FontFamily
 
   colors:
-    # Optional
-    enabled: true
-    # Optional
-    inputs: []
-    # Optional
-    outputs:
+    enabled: true # Optional
+    inputs: [] # Optional
+    outputs: # Optional
       class_name: ColorName
 
 flutter:

--- a/packages/core/lib/settings/pubspec.dart
+++ b/packages/core/lib/settings/pubspec.dart
@@ -114,8 +114,8 @@ class FlutterGen {
   @JsonKey(name: 'output', required: true)
   final String output;
 
-  @JsonKey(name: 'line_length', required: true)
-  final int lineLength;
+  @JsonKey(name: 'line_length')
+  final int? lineLength;
 
   @JsonKey(name: 'parse_metadata', required: true)
   final bool parseMetadata;

--- a/packages/core/lib/settings/pubspec.g.dart
+++ b/packages/core/lib/settings/pubspec.g.dart
@@ -81,7 +81,6 @@ FlutterGen _$FlutterGenFromJson(Map json) => $checkedCreate(
           ],
           requiredKeys: const [
             'output',
-            'line_length',
             'parse_metadata',
             'assets',
             'fonts',
@@ -91,7 +90,8 @@ FlutterGen _$FlutterGenFromJson(Map json) => $checkedCreate(
         );
         final val = FlutterGen(
           output: $checkedConvert('output', (v) => v as String),
-          lineLength: $checkedConvert('line_length', (v) => (v as num).toInt()),
+          lineLength:
+              $checkedConvert('line_length', (v) => (v as num?)?.toInt()),
           parseMetadata: $checkedConvert('parse_metadata', (v) => v as bool),
           assets: $checkedConvert(
               'assets', (v) => FlutterGenAssets.fromJson(v as Map)),

--- a/packages/core/lib/utils/cast.dart
+++ b/packages/core/lib/utils/cast.dart
@@ -1,1 +1,9 @@
-T? safeCast<T>(dynamic value) => value is T ? value : null;
+/// Returns the value if it is the same type as [T], otherwise `null`.
+///
+/// [T] must be non-nullable since the return type is nullable.
+T? safeCast<T extends Object>(Object? value) {
+  return switch (value) {
+    final T v => v,
+    _ => null,
+  };
+}

--- a/packages/core/lib/utils/formatter.dart
+++ b/packages/core/lib/utils/formatter.dart
@@ -1,3 +1,5 @@
+import 'dart:io' as io show Platform;
+
 import 'package:dart_style/dart_style.dart' show DartFormatter;
 import 'package:pub_semver/pub_semver.dart' show VersionConstraint;
 
@@ -5,11 +7,12 @@ import '../settings/config.dart' show Config;
 
 /// The formatter will only use the tall-style if the SDK constraint is ^3.7.
 DartFormatter buildDartFormatterFromConfig(Config config) {
-  final sdkConstraint = config.pubspec.environment['sdk'];
-  final useShort = switch (sdkConstraint) {
-    final c? => c.allowsAny(VersionConstraint.parse('<3.7.0')),
-    _ => true,
-  };
+  VersionConstraint? sdkConstraint = config.sdkConstraint;
+  if (sdkConstraint == null) {
+    final version = io.Platform.version.split(' ').first;
+    sdkConstraint = VersionConstraint.parse('^$version');
+  }
+  final useShort = sdkConstraint.allowsAny(VersionConstraint.parse('<3.7.0'));
   return DartFormatter(
     languageVersion: useShort
         ? DartFormatter.latestShortStyleLanguageVersion

--- a/packages/core/lib/utils/formatter.dart
+++ b/packages/core/lib/utils/formatter.dart
@@ -13,11 +13,16 @@ DartFormatter buildDartFormatterFromConfig(Config config) {
     sdkConstraint = VersionConstraint.parse('^$version');
   }
   final useShort = sdkConstraint.allowsAny(VersionConstraint.parse('<3.7.0'));
+
+  final pageWidth =
+      config.pubspec.flutterGen.lineLength ?? config.formatterPageWidth;
+
   return DartFormatter(
     languageVersion: useShort
         ? DartFormatter.latestShortStyleLanguageVersion
         : DartFormatter.latestLanguageVersion,
-    pageWidth: config.pubspec.flutterGen.lineLength,
+    pageWidth: pageWidth,
+    // trailingCommas: config.formatterTrailingCommas,
     lineEnding: '\n',
   );
 }

--- a/packages/core/lib/utils/map.dart
+++ b/packages/core/lib/utils/map.dart
@@ -1,7 +1,7 @@
 // Copy from https://pub.dev/packages/merge_map
 
 /// Exposes the [mergeMap] function, which... merges Maps.
-_copyValues<K, V>(
+void _copyValues<K, V>(
   Map<K, V> from,
   Map<K, V> to,
   bool recursive,

--- a/packages/core/scripts/generate_facts.dart
+++ b/packages/core/scripts/generate_facts.dart
@@ -33,7 +33,9 @@ void main() async {
       overrideOutputPath: p.join(dir.path, 'actual_data'),
     );
     await generator.build().catchError((e, s) {
-      stderr.writeln('$e\n$s');
+      stderr.writeln('[FAILED] ${file.name} - ${buildFile?.name ?? 'N/A'}');
+      stderr.writeln('$e');
+      stderr.writeln('$s');
     });
   }
 }

--- a/packages/core/test_resources/actual_data/assets_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/core/test_resources/actual_data/assets_assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_camel_case.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -13,20 +15,24 @@ class Assets {
   const Assets._();
 
   /// File path: assets/images/chip1.jpg
-  static const AssetGenImage imagesChip1 =
-      AssetGenImage('assets/images/chip1.jpg');
+  static const AssetGenImage imagesChip1 = AssetGenImage(
+    'assets/images/chip1.jpg',
+  );
 
   /// File path: assets/images/chip2.jpg
-  static const AssetGenImage imagesChip2 =
-      AssetGenImage('assets/images/chip2.jpg');
+  static const AssetGenImage imagesChip2 = AssetGenImage(
+    'assets/images/chip2.jpg',
+  );
 
   /// File path: assets/images/chip3/chip3.jpg
-  static const AssetGenImage imagesChip3Chip3 =
-      AssetGenImage('assets/images/chip3/chip3.jpg');
+  static const AssetGenImage imagesChip3Chip3 = AssetGenImage(
+    'assets/images/chip3/chip3.jpg',
+  );
 
   /// File path: assets/images/chip4/chip4.jpg
-  static const AssetGenImage imagesChip4Chip4 =
-      AssetGenImage('assets/images/chip4/chip4.jpg');
+  static const AssetGenImage imagesChip4Chip4 = AssetGenImage(
+    'assets/images/chip4/chip4.jpg',
+  );
 
   /// File path: assets/images/icons/dart@test.svg
   static const String imagesIconsDartTest = 'assets/images/icons/dart@test.svg';
@@ -41,16 +47,19 @@ class Assets {
   static const String imagesIconsPaint = 'assets/images/icons/paint.svg';
 
   /// File path: assets/images/logo.png
-  static const AssetGenImage imagesLogo =
-      AssetGenImage('assets/images/logo.png');
+  static const AssetGenImage imagesLogo = AssetGenImage(
+    'assets/images/logo.png',
+  );
 
   /// File path: assets/images/profile.jpg
-  static const AssetGenImage imagesProfileJpg =
-      AssetGenImage('assets/images/profile.jpg');
+  static const AssetGenImage imagesProfileJpg = AssetGenImage(
+    'assets/images/profile.jpg',
+  );
 
   /// File path: assets/images/profile.png
-  static const AssetGenImage imagesProfilePng =
-      AssetGenImage('assets/images/profile.png');
+  static const AssetGenImage imagesProfilePng = AssetGenImage(
+    'assets/images/profile.png',
+  );
 
   /// File path: assets/json/list.json
   static const String jsonList = 'assets/json/list.json';
@@ -59,34 +68,31 @@ class Assets {
   static const String jsonMap = 'assets/json/map.json';
 
   /// File path: pictures/chip5.jpg
-  static const AssetGenImage picturesChip5 =
-      AssetGenImage('pictures/chip5.jpg');
+  static const AssetGenImage picturesChip5 = AssetGenImage(
+    'pictures/chip5.jpg',
+  );
 
   /// List of all assets
   static List<dynamic> get values => [
-        imagesChip1,
-        imagesChip2,
-        imagesChip3Chip3,
-        imagesChip4Chip4,
-        imagesIconsDartTest,
-        imagesIconsFuchsia,
-        imagesIconsKmm,
-        imagesIconsPaint,
-        imagesLogo,
-        imagesProfileJpg,
-        imagesProfilePng,
-        jsonList,
-        jsonMap,
-        picturesChip5
-      ];
+    imagesChip1,
+    imagesChip2,
+    imagesChip3Chip3,
+    imagesChip4Chip4,
+    imagesIconsDartTest,
+    imagesIconsFuchsia,
+    imagesIconsKmm,
+    imagesIconsPaint,
+    imagesLogo,
+    imagesProfileJpg,
+    imagesProfilePng,
+    jsonList,
+    jsonMap,
+    picturesChip5,
+  ];
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -146,15 +152,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/packages/core/test_resources/actual_data/assets_assets_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_change_class_name.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -30,8 +32,13 @@ class $AssetsImagesGen {
       const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class MyAssets {
@@ -41,11 +48,7 @@ class MyAssets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -105,15 +108,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/packages/core/test_resources/actual_data/assets_assets_directory_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_directory_path.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -78,11 +80,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -142,15 +140,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;
@@ -159,17 +150,11 @@ class AssetGenImage {
 }
 
 class SvgGenImage {
-  const SvgGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -225,7 +210,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_directory_path_with_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_directory_path_with_package_parameter.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -81,11 +83,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -153,11 +151,7 @@ class AssetGenImage {
     @Deprecated('Do not specify package for a generated library asset')
     String? package = package,
   }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;
@@ -166,17 +160,11 @@ class AssetGenImage {
 }
 
 class SvgGenImage {
-  const SvgGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -235,7 +223,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_exclude_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_exclude_files.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -71,11 +73,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -135,15 +133,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/packages/core/test_resources/actual_data/assets_assets_flavored.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_flavored.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -62,8 +64,13 @@ class $AssetsImagesGen {
       const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {
@@ -114,10 +121,8 @@ class $AssetsImagesChip4Gen {
   const $AssetsImagesChip4Gen();
 
   /// File path: assets/images/chip4/chip4.jpg
-  AssetGenImage get chip4 => const AssetGenImage(
-        'assets/images/chip4/chip4.jpg',
-        flavors: {'test'},
-      );
+  AssetGenImage get chip4 =>
+      const AssetGenImage('assets/images/chip4/chip4.jpg', flavors: {'test'});
 
   /// List of all assets
   List<AssetGenImage> get values => [chip4];
@@ -160,11 +165,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -224,15 +225,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;
@@ -241,17 +235,11 @@ class AssetGenImage {
 }
 
 class SvgGenImage {
-  const SvgGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -307,7 +295,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_lottie_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_lottie_integrations.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 import 'package:lottie/lottie.dart' as _lottie;
@@ -30,8 +32,12 @@ class $AssetsLottieGen {
       const LottieGenImage('assets/lottie/spinning_carrousel.zip');
 
   /// List of all assets
-  List<LottieGenImage> get values =>
-      [xuiIZ9X1Rf, catCat, hamburgerArrow, spinningCarrousel];
+  List<LottieGenImage> get values => [
+    xuiIZ9X1Rf,
+    catCat,
+    hamburgerArrow,
+    spinningCarrousel,
+  ];
 }
 
 class Assets {
@@ -41,10 +47,7 @@ class Assets {
 }
 
 class LottieGenImage {
-  const LottieGenImage(
-    this._assetName, {
-    this.flavors = const {},
-  });
+  const LottieGenImage(this._assetName, {this.flavors = const {}});
 
   final String _assetName;
   final Set<String> flavors;
@@ -61,11 +64,8 @@ class LottieGenImage {
     _lottie.LottieImageProviderFactory? imageProviderFactory,
     Key? key,
     AssetBundle? bundle,
-    Widget Function(
-      BuildContext,
-      Widget,
-      _lottie.LottieComposition?,
-    )? frameBuilder,
+    Widget Function(BuildContext, Widget, _lottie.LottieComposition?)?
+    frameBuilder,
     ImageErrorWidgetBuilder? errorBuilder,
     double? width,
     double? height,

--- a/packages/core/test_resources/actual_data/assets_assets_no_image_integration.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_no_image_integration.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class $PicturesGen {
   const $PicturesGen();

--- a/packages/core/test_resources/actual_data/assets_assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_no_integrations.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -49,8 +51,13 @@ class $AssetsImagesGen {
       const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {
@@ -116,11 +123,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -180,15 +183,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/packages/core/test_resources/actual_data/assets_assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_package_parameter.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -69,11 +71,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -141,11 +139,7 @@ class AssetGenImage {
     @Deprecated('Do not specify package for a generated library asset')
     String? package = package,
   }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;
@@ -154,17 +148,11 @@ class AssetGenImage {
 }
 
 class SvgGenImage {
-  const SvgGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -223,7 +211,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_package_parameter_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_package_parameter_disable_null_safety.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -57,11 +59,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -129,11 +127,7 @@ class AssetGenImage {
     @Deprecated('Do not specify package for a generated library asset')
     String? package = package,
   }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;
@@ -142,17 +136,11 @@ class AssetGenImage {
 }
 
 class SvgGenImage {
-  const SvgGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -211,7 +199,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_parse_metadata.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_parse_metadata.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -65,8 +67,13 @@ class $AssetsImagesGen {
       const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {
@@ -106,9 +113,10 @@ class $AssetsImagesChip3Gen {
   const $AssetsImagesChip3Gen();
 
   /// File path: assets/images/chip3/chip3.jpg
-  AssetGenImage get chip3 =>
-      const AssetGenImage('assets/images/chip3/chip3.jpg',
-          size: Size(600.0, 403.0));
+  AssetGenImage get chip3 => const AssetGenImage(
+    'assets/images/chip3/chip3.jpg',
+    size: Size(600.0, 403.0),
+  );
 
   /// List of all assets
   List<AssetGenImage> get values => [chip3];
@@ -118,9 +126,10 @@ class $AssetsImagesChip4Gen {
   const $AssetsImagesChip4Gen();
 
   /// File path: assets/images/chip4/chip4.jpg
-  AssetGenImage get chip4 =>
-      const AssetGenImage('assets/images/chip4/chip4.jpg',
-          size: Size(600.0, 403.0));
+  AssetGenImage get chip4 => const AssetGenImage(
+    'assets/images/chip4/chip4.jpg',
+    size: Size(600.0, 403.0),
+  );
 
   /// List of all assets
   List<AssetGenImage> get values => [chip4];
@@ -130,26 +139,32 @@ class $AssetsImagesIconsGen {
   const $AssetsImagesIconsGen();
 
   /// File path: assets/images/icons/dart@test.svg
-  SvgGenImage get dartTest =>
-      const SvgGenImage('assets/images/icons/dart@test.svg',
-          size: Size(512.001, 512.001));
+  SvgGenImage get dartTest => const SvgGenImage(
+    'assets/images/icons/dart@test.svg',
+    size: Size(512.001, 512.001),
+  );
 
   /// File path: assets/images/icons/fuchsia.svg
-  SvgGenImage get fuchsia =>
-      const SvgGenImage('assets/images/icons/fuchsia.svg',
-          size: Size(50.0, 50.0));
+  SvgGenImage get fuchsia => const SvgGenImage(
+    'assets/images/icons/fuchsia.svg',
+    size: Size(50.0, 50.0),
+  );
 
   /// File path: assets/images/icons/invalid.svg
   SvgGenImage get invalid =>
       const SvgGenImage('assets/images/icons/invalid.svg');
 
   /// File path: assets/images/icons/kmm.svg
-  SvgGenImage get kmm => const SvgGenImage('assets/images/icons/kmm.svg',
-      size: Size(755.0, 310.0));
+  SvgGenImage get kmm => const SvgGenImage(
+    'assets/images/icons/kmm.svg',
+    size: Size(755.0, 310.0),
+  );
 
   /// File path: assets/images/icons/paint.svg
-  SvgGenImage get paint => const SvgGenImage('assets/images/icons/paint.svg',
-      size: Size(472.0, 392.0));
+  SvgGenImage get paint => const SvgGenImage(
+    'assets/images/icons/paint.svg',
+    size: Size(472.0, 392.0),
+  );
 
   /// List of all assets
   List<SvgGenImage> get values => [dartTest, fuchsia, invalid, kmm, paint];
@@ -167,11 +182,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -231,15 +242,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;
@@ -248,17 +252,11 @@ class AssetGenImage {
 }
 
 class SvgGenImage {
-  const SvgGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -314,7 +312,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_rive_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_rive_integrations.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 import 'package:rive/rive.dart' as _rive;
@@ -27,10 +29,7 @@ class Assets {
 }
 
 class RiveGenImage {
-  const RiveGenImage(
-    this._assetName, {
-    this.flavors = const {},
-  });
+  const RiveGenImage(this._assetName, {this.flavors = const {}});
 
   final String _assetName;
   final Set<String> flavors;

--- a/packages/core/test_resources/actual_data/assets_assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_snake_case.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -13,20 +15,24 @@ class Assets {
   const Assets._();
 
   /// File path: assets/images/chip1.jpg
-  static const AssetGenImage images_chip1 =
-      AssetGenImage('assets/images/chip1.jpg');
+  static const AssetGenImage images_chip1 = AssetGenImage(
+    'assets/images/chip1.jpg',
+  );
 
   /// File path: assets/images/chip2.jpg
-  static const AssetGenImage images_chip2 =
-      AssetGenImage('assets/images/chip2.jpg');
+  static const AssetGenImage images_chip2 = AssetGenImage(
+    'assets/images/chip2.jpg',
+  );
 
   /// File path: assets/images/chip3/chip3.jpg
-  static const AssetGenImage images_chip3_chip3 =
-      AssetGenImage('assets/images/chip3/chip3.jpg');
+  static const AssetGenImage images_chip3_chip3 = AssetGenImage(
+    'assets/images/chip3/chip3.jpg',
+  );
 
   /// File path: assets/images/chip4/chip4.jpg
-  static const AssetGenImage images_chip4_chip4 =
-      AssetGenImage('assets/images/chip4/chip4.jpg');
+  static const AssetGenImage images_chip4_chip4 = AssetGenImage(
+    'assets/images/chip4/chip4.jpg',
+  );
 
   /// File path: assets/images/icons/dart@test.svg
   static const String images_icons_dart_test =
@@ -42,16 +48,19 @@ class Assets {
   static const String images_icons_paint = 'assets/images/icons/paint.svg';
 
   /// File path: assets/images/logo.png
-  static const AssetGenImage images_logo =
-      AssetGenImage('assets/images/logo.png');
+  static const AssetGenImage images_logo = AssetGenImage(
+    'assets/images/logo.png',
+  );
 
   /// File path: assets/images/profile.jpg
-  static const AssetGenImage images_profile_jpg =
-      AssetGenImage('assets/images/profile.jpg');
+  static const AssetGenImage images_profile_jpg = AssetGenImage(
+    'assets/images/profile.jpg',
+  );
 
   /// File path: assets/images/profile.png
-  static const AssetGenImage images_profile_png =
-      AssetGenImage('assets/images/profile.png');
+  static const AssetGenImage images_profile_png = AssetGenImage(
+    'assets/images/profile.png',
+  );
 
   /// File path: assets/json/list.json
   static const String json_list = 'assets/json/list.json';
@@ -60,34 +69,31 @@ class Assets {
   static const String json_map = 'assets/json/map.json';
 
   /// File path: pictures/chip5.jpg
-  static const AssetGenImage pictures_chip5 =
-      AssetGenImage('pictures/chip5.jpg');
+  static const AssetGenImage pictures_chip5 = AssetGenImage(
+    'pictures/chip5.jpg',
+  );
 
   /// List of all assets
   static List<dynamic> get values => [
-        images_chip1,
-        images_chip2,
-        images_chip3_chip3,
-        images_chip4_chip4,
-        images_icons_dart_test,
-        images_icons_fuchsia,
-        images_icons_kmm,
-        images_icons_paint,
-        images_logo,
-        images_profile_jpg,
-        images_profile_png,
-        json_list,
-        json_map,
-        pictures_chip5
-      ];
+    images_chip1,
+    images_chip2,
+    images_chip3_chip3,
+    images_chip4_chip4,
+    images_icons_dart_test,
+    images_icons_fuchsia,
+    images_icons_kmm,
+    images_icons_paint,
+    images_logo,
+    images_profile_jpg,
+    images_profile_png,
+    json_list,
+    json_map,
+    pictures_chip5,
+  ];
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -147,15 +153,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/packages/core/test_resources/actual_data/assets_assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_svg_integrations.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -44,17 +46,11 @@ class Assets {
 }
 
 class SvgGenImage {
-  const SvgGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -110,7 +106,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_change_output_path.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -30,8 +32,13 @@ class $AssetsImagesGen {
       const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class Assets {
@@ -41,11 +48,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -105,15 +108,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class $AssetsUnknownGen {
   const $AssetsUnknownGen();

--- a/packages/core/test_resources/actual_data/assets_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_normal.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -52,8 +54,13 @@ class $AssetsImagesGen {
       const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {
@@ -121,11 +128,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -185,15 +188,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;
@@ -202,17 +198,11 @@ class AssetGenImage {
 }
 
 class SvgGenImage {
-  const SvgGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = false;
+  const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = false;
 
-  const SvgGenImage.vec(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  }) : _isVecFormat = true;
+  const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -268,7 +258,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_only_flutter_value.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_only_flutter_value.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -30,8 +32,13 @@ class $AssetsImagesGen {
       const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class Assets {
@@ -41,11 +48,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -105,15 +108,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class $AssetsUnknownGen {
   const $AssetsUnknownGen();

--- a/packages/core/test_resources/actual_data/assets_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_wrong_output_path.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -30,8 +32,13 @@ class $AssetsImagesGen {
       const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class Assets {
@@ -41,11 +48,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -105,15 +108,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/packages/core/test_resources/actual_data/build_assets_build_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_assets.gen.dart
@@ -1,4 +1,4 @@
-// dart format width=120
+// dart format width=80
 
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
@@ -56,13 +56,16 @@ class $AssetsImagesGen {
   AssetGenImage get logo => const AssetGenImage('assets/images/logo.png');
 
   /// File path: assets/images/profile.jpg
-  AssetGenImage get profileJpg => const AssetGenImage('assets/images/profile.jpg');
+  AssetGenImage get profileJpg =>
+      const AssetGenImage('assets/images/profile.jpg');
 
   /// File path: assets/images/profile.png
-  AssetGenImage get profilePng => const AssetGenImage('assets/images/profile.png');
+  AssetGenImage get profilePng =>
+      const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values => [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values =>
+      [chip1, chip2, logo, profileJpg, profilePng];
 }
 
 class $AssetsJsonGen {
@@ -102,7 +105,8 @@ class $AssetsImagesChip3Gen {
   const $AssetsImagesChip3Gen();
 
   /// File path: assets/images/chip3/chip3.jpg
-  AssetGenImage get chip3 => const AssetGenImage('assets/images/chip3/chip3.jpg');
+  AssetGenImage get chip3 =>
+      const AssetGenImage('assets/images/chip3/chip3.jpg');
 
   /// List of all assets
   List<AssetGenImage> get values => [chip3];
@@ -112,7 +116,8 @@ class $AssetsImagesChip4Gen {
   const $AssetsImagesChip4Gen();
 
   /// File path: assets/images/chip4/chip4.jpg
-  AssetGenImage get chip4 => const AssetGenImage('assets/images/chip4/chip4.jpg');
+  AssetGenImage get chip4 =>
+      const AssetGenImage('assets/images/chip4/chip4.jpg');
 
   /// List of all assets
   List<AssetGenImage> get values => [chip4];
@@ -122,10 +127,12 @@ class $AssetsImagesIconsGen {
   const $AssetsImagesIconsGen();
 
   /// File path: assets/images/icons/dart@test.svg
-  SvgGenImage get dartTest => const SvgGenImage('assets/images/icons/dart@test.svg');
+  SvgGenImage get dartTest =>
+      const SvgGenImage('assets/images/icons/dart@test.svg');
 
   /// File path: assets/images/icons/fuchsia.svg
-  SvgGenImage get fuchsia => const SvgGenImage('assets/images/icons/fuchsia.svg');
+  SvgGenImage get fuchsia =>
+      const SvgGenImage('assets/images/icons/fuchsia.svg');
 
   /// File path: assets/images/icons/kmm.svg
   SvgGenImage get kmm => const SvgGenImage('assets/images/icons/kmm.svg');
@@ -300,7 +307,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ?? (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
+      colorFilter: colorFilter ??
+          (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,
     );

--- a/packages/core/test_resources/actual_data/build_assets_build_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_assets.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=120
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/core/test_resources/actual_data/build_assets_build_empty.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_empty.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/core/test_resources/actual_data/build_assets_build_runner_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_runner_assets.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=120
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
@@ -27,21 +28,19 @@ class ColorName {
   ///   700: #FFC31F1F
   ///   800: #FFBD1919
   ///   900: #FFB20F0F
-  static const MaterialColor crimsonRed = MaterialColor(
-    0xFFCF2A2A,
-    <int, Color>{
-      50: Color(0xFFF9E5E5),
-      100: Color(0xFFF1BFBF),
-      200: Color(0xFFE79595),
-      300: Color(0xFFDD6A6A),
-      400: Color(0xFFD64A4A),
-      500: Color(0xFFCF2A2A),
-      600: Color(0xFFCA2525),
-      700: Color(0xFFC31F1F),
-      800: Color(0xFFBD1919),
-      900: Color(0xFFB20F0F),
-    },
-  );
+  static const MaterialColor crimsonRed =
+      MaterialColor(0xFFCF2A2A, <int, Color>{
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -63,34 +62,30 @@ class ColorName {
   ///   700: #FFD7821D
   ///   800: #FFD27817
   ///   900: #FFCA670E
-  static const MaterialColor yellowOcher = MaterialColor(
-    0xFFDF9527,
-    <int, Color>{
-      50: Color(0xFFFBF2E5),
-      100: Color(0xFFF5DFBE),
-      200: Color(0xFFEFCA93),
-      300: Color(0xFFE9B568),
-      400: Color(0xFFE4A547),
-      500: Color(0xFFDF9527),
-      600: Color(0xFFDB8D23),
-      700: Color(0xFFD7821D),
-      800: Color(0xFFD27817),
-      900: Color(0xFFCA670E),
-    },
-  );
+  static const MaterialColor yellowOcher =
+      MaterialColor(0xFFDF9527, <int, Color>{
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
   ///   200: #FFFFBCA3
   ///   400: #FFFFA989
   ///   700: #FFFF9E7A
-  static const MaterialAccentColor yellowOcherAccent = MaterialAccentColor(
-    0xFFFFBCA3,
-    <int, Color>{
-      100: Color(0xFFFFE8E0),
-      200: Color(0xFFFFBCA3),
-      400: Color(0xFFFFA989),
-      700: Color(0xFFFF9E7A),
-    },
-  );
+  static const MaterialAccentColor yellowOcherAccent =
+      MaterialAccentColor(0xFFFFBCA3, <int, Color>{
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/colors_colors.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';

--- a/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
@@ -27,21 +28,19 @@ class MyColorName {
   ///   700: #FFC31F1F
   ///   800: #FFBD1919
   ///   900: #FFB20F0F
-  static const MaterialColor crimsonRed = MaterialColor(
-    0xFFCF2A2A,
-    <int, Color>{
-      50: Color(0xFFF9E5E5),
-      100: Color(0xFFF1BFBF),
-      200: Color(0xFFE79595),
-      300: Color(0xFFDD6A6A),
-      400: Color(0xFFD64A4A),
-      500: Color(0xFFCF2A2A),
-      600: Color(0xFFCA2525),
-      700: Color(0xFFC31F1F),
-      800: Color(0xFFBD1919),
-      900: Color(0xFFB20F0F),
-    },
-  );
+  static const MaterialColor crimsonRed =
+      MaterialColor(0xFFCF2A2A, <int, Color>{
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -63,34 +62,30 @@ class MyColorName {
   ///   700: #FFD7821D
   ///   800: #FFD27817
   ///   900: #FFCA670E
-  static const MaterialColor yellowOcher = MaterialColor(
-    0xFFDF9527,
-    <int, Color>{
-      50: Color(0xFFFBF2E5),
-      100: Color(0xFFF5DFBE),
-      200: Color(0xFFEFCA93),
-      300: Color(0xFFE9B568),
-      400: Color(0xFFE4A547),
-      500: Color(0xFFDF9527),
-      600: Color(0xFFDB8D23),
-      700: Color(0xFFD7821D),
-      800: Color(0xFFD27817),
-      900: Color(0xFFCA670E),
-    },
-  );
+  static const MaterialColor yellowOcher =
+      MaterialColor(0xFFDF9527, <int, Color>{
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
   ///   200: #FFFFBCA3
   ///   400: #FFFFA989
   ///   700: #FFFF9E7A
-  static const MaterialAccentColor yellowOcherAccent = MaterialAccentColor(
-    0xFFFFBCA3,
-    <int, Color>{
-      100: Color(0xFFFFE8E0),
-      200: Color(0xFFFFBCA3),
-      400: Color(0xFFFFA989),
-      700: Color(0xFFFF9E7A),
-    },
-  );
+  static const MaterialAccentColor yellowOcherAccent =
+      MaterialAccentColor(0xFFFFBCA3, <int, Color>{
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/colors_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_normal.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
@@ -39,21 +40,19 @@ class ColorName {
   ///   700: #FFC31F1F
   ///   800: #FFBD1919
   ///   900: #FFB20F0F
-  static const MaterialColor crimsonRed = MaterialColor(
-    0xFFCF2A2A,
-    <int, Color>{
-      50: Color(0xFFF9E5E5),
-      100: Color(0xFFF1BFBF),
-      200: Color(0xFFE79595),
-      300: Color(0xFFDD6A6A),
-      400: Color(0xFFD64A4A),
-      500: Color(0xFFCF2A2A),
-      600: Color(0xFFCA2525),
-      700: Color(0xFFC31F1F),
-      800: Color(0xFFBD1919),
-      900: Color(0xFFB20F0F),
-    },
-  );
+  static const MaterialColor crimsonRed =
+      MaterialColor(0xFFCF2A2A, <int, Color>{
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -75,34 +74,30 @@ class ColorName {
   ///   700: #FFD7821D
   ///   800: #FFD27817
   ///   900: #FFCA670E
-  static const MaterialColor yellowOcher = MaterialColor(
-    0xFFDF9527,
-    <int, Color>{
-      50: Color(0xFFFBF2E5),
-      100: Color(0xFFF5DFBE),
-      200: Color(0xFFEFCA93),
-      300: Color(0xFFE9B568),
-      400: Color(0xFFE4A547),
-      500: Color(0xFFDF9527),
-      600: Color(0xFFDB8D23),
-      700: Color(0xFFD7821D),
-      800: Color(0xFFD27817),
-      900: Color(0xFFCA670E),
-    },
-  );
+  static const MaterialColor yellowOcher =
+      MaterialColor(0xFFDF9527, <int, Color>{
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
   ///   200: #FFFFBCA3
   ///   400: #FFFFA989
   ///   700: #FFFF9E7A
-  static const MaterialAccentColor yellowOcherAccent = MaterialAccentColor(
-    0xFFFFBCA3,
-    <int, Color>{
-      100: Color(0xFFFFE8E0),
-      200: Color(0xFFFFBCA3),
-      400: Color(0xFFFFA989),
-      700: Color(0xFFFF9E7A),
-    },
-  );
+  static const MaterialAccentColor yellowOcherAccent =
+      MaterialAccentColor(0xFFFFBCA3, <int, Color>{
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
@@ -27,21 +28,19 @@ class ColorName {
   ///   700: #FFC31F1F
   ///   800: #FFBD1919
   ///   900: #FFB20F0F
-  static const MaterialColor crimsonRed = MaterialColor(
-    0xFFCF2A2A,
-    <int, Color>{
-      50: Color(0xFFF9E5E5),
-      100: Color(0xFFF1BFBF),
-      200: Color(0xFFE79595),
-      300: Color(0xFFDD6A6A),
-      400: Color(0xFFD64A4A),
-      500: Color(0xFFCF2A2A),
-      600: Color(0xFFCA2525),
-      700: Color(0xFFC31F1F),
-      800: Color(0xFFBD1919),
-      900: Color(0xFFB20F0F),
-    },
-  );
+  static const MaterialColor crimsonRed =
+      MaterialColor(0xFFCF2A2A, <int, Color>{
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -63,34 +62,30 @@ class ColorName {
   ///   700: #FFD7821D
   ///   800: #FFD27817
   ///   900: #FFCA670E
-  static const MaterialColor yellowOcher = MaterialColor(
-    0xFFDF9527,
-    <int, Color>{
-      50: Color(0xFFFBF2E5),
-      100: Color(0xFFF5DFBE),
-      200: Color(0xFFEFCA93),
-      300: Color(0xFFE9B568),
-      400: Color(0xFFE4A547),
-      500: Color(0xFFDF9527),
-      600: Color(0xFFDB8D23),
-      700: Color(0xFFD7821D),
-      800: Color(0xFFD27817),
-      900: Color(0xFFCA670E),
-    },
-  );
+  static const MaterialColor yellowOcher =
+      MaterialColor(0xFFDF9527, <int, Color>{
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
   ///   200: #FFFFBCA3
   ///   400: #FFFFA989
   ///   700: #FFFF9E7A
-  static const MaterialAccentColor yellowOcherAccent = MaterialAccentColor(
-    0xFFFFBCA3,
-    <int, Color>{
-      100: Color(0xFFFFE8E0),
-      200: Color(0xFFFFBCA3),
-      400: Color(0xFFFFA989),
-      700: Color(0xFFFF9E7A),
-    },
-  );
+  static const MaterialAccentColor yellowOcherAccent =
+      MaterialAccentColor(0xFFFFBCA3, <int, Color>{
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
@@ -27,21 +28,19 @@ class ColorName {
   ///   700: #FFC31F1F
   ///   800: #FFBD1919
   ///   900: #FFB20F0F
-  static const MaterialColor crimsonRed = MaterialColor(
-    0xFFCF2A2A,
-    <int, Color>{
-      50: Color(0xFFF9E5E5),
-      100: Color(0xFFF1BFBF),
-      200: Color(0xFFE79595),
-      300: Color(0xFFDD6A6A),
-      400: Color(0xFFD64A4A),
-      500: Color(0xFFCF2A2A),
-      600: Color(0xFFCA2525),
-      700: Color(0xFFC31F1F),
-      800: Color(0xFFBD1919),
-      900: Color(0xFFB20F0F),
-    },
-  );
+  static const MaterialColor crimsonRed =
+      MaterialColor(0xFFCF2A2A, <int, Color>{
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -63,34 +62,30 @@ class ColorName {
   ///   700: #FFD7821D
   ///   800: #FFD27817
   ///   900: #FFCA670E
-  static const MaterialColor yellowOcher = MaterialColor(
-    0xFFDF9527,
-    <int, Color>{
-      50: Color(0xFFFBF2E5),
-      100: Color(0xFFF5DFBE),
-      200: Color(0xFFEFCA93),
-      300: Color(0xFFE9B568),
-      400: Color(0xFFE4A547),
-      500: Color(0xFFDF9527),
-      600: Color(0xFFDB8D23),
-      700: Color(0xFFD7821D),
-      800: Color(0xFFD27817),
-      900: Color(0xFFCA670E),
-    },
-  );
+  static const MaterialColor yellowOcher =
+      MaterialColor(0xFFDF9527, <int, Color>{
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
   ///   200: #FFFFBCA3
   ///   400: #FFFFA989
   ///   700: #FFFF9E7A
-  static const MaterialAccentColor yellowOcherAccent = MaterialAccentColor(
-    0xFFFFBCA3,
-    <int, Color>{
-      100: Color(0xFFFFE8E0),
-      200: Color(0xFFFFBCA3),
-      400: Color(0xFFFFA989),
-      700: Color(0xFFFF9E7A),
-    },
-  );
+  static const MaterialAccentColor yellowOcherAccent =
+      MaterialAccentColor(0xFFFFBCA3, <int, Color>{
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/fonts_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_change_output_path.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
   FontFamily._();

--- a/packages/core/test_resources/actual_data/fonts_fonts.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
   FontFamily._();

--- a/packages/core/test_resources/actual_data/fonts_fonts_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts_change_class_name.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class MyFontFamily {
   MyFontFamily._();

--- a/packages/core/test_resources/actual_data/fonts_fonts_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts_package_parameter.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
   FontFamily._();

--- a/packages/core/test_resources/actual_data/fonts_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_normal.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
   FontFamily._();

--- a/packages/core/test_resources/actual_data/fonts_only_flutter_value.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_only_flutter_value.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
   FontFamily._();

--- a/packages/core/test_resources/actual_data/fonts_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_wrong_output_path.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +6,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
   FontFamily._();

--- a/packages/core/test_resources/build_assets.yaml
+++ b/packages/core/test_resources/build_assets.yaml
@@ -6,4 +6,4 @@ targets:
       flutter_gen:
         options:
           output: lib/build_gen/
-          line_length: 120
+          line_length: 80

--- a/packages/core/test_resources/pubspec_assets.yaml
+++ b/packages/core/test_resources/pubspec_assets.yaml
@@ -1,8 +1,11 @@
 name: test
 
+environment:
+  sdk: ^3.4.0
+
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
+  line_length: 80 # Optional
 
   integrations:
     flutter_svg: true

--- a/packages/core/test_resources/pubspec_assets_camel_case.yaml
+++ b/packages/core/test_resources/pubspec_assets_camel_case.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   assets:
     outputs:

--- a/packages/core/test_resources/pubspec_assets_change_class_name.yaml
+++ b/packages/core/test_resources/pubspec_assets_change_class_name.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   assets:
     outputs:

--- a/packages/core/test_resources/pubspec_assets_exclude_files.yaml
+++ b/packages/core/test_resources/pubspec_assets_exclude_files.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/
-  line_length: 80
 
   integrations:
     flutter_svg: true

--- a/packages/core/test_resources/pubspec_assets_flavored.yaml
+++ b/packages/core/test_resources/pubspec_assets_flavored.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   integrations:
     flutter_svg: true

--- a/packages/core/test_resources/pubspec_assets_flavored_duplicate_entry.yaml
+++ b/packages/core/test_resources/pubspec_assets_flavored_duplicate_entry.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   integrations:
     flutter_svg: true

--- a/packages/core/test_resources/pubspec_assets_lottie_integrations.yaml
+++ b/packages/core/test_resources/pubspec_assets_lottie_integrations.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/
-  line_length: 80
 
   integrations:
     lottie: true

--- a/packages/core/test_resources/pubspec_assets_no_image_integration.yaml
+++ b/packages/core/test_resources/pubspec_assets_no_image_integration.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   integrations:
     image: false

--- a/packages/core/test_resources/pubspec_assets_no_integrations.yaml
+++ b/packages/core/test_resources/pubspec_assets_no_integrations.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
 flutter:
   assets:

--- a/packages/core/test_resources/pubspec_assets_no_list.yaml
+++ b/packages/core/test_resources/pubspec_assets_no_list.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   integrations:
     flutter_svg: true

--- a/packages/core/test_resources/pubspec_assets_parse_metadata.yaml
+++ b/packages/core/test_resources/pubspec_assets_parse_metadata.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
   parse_metadata: true # Optional (default: false)
 
   integrations:

--- a/packages/core/test_resources/pubspec_assets_rive_integrations.yaml
+++ b/packages/core/test_resources/pubspec_assets_rive_integrations.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/
-  line_length: 80
 
   integrations:
     rive: true

--- a/packages/core/test_resources/pubspec_assets_snake_case.yaml
+++ b/packages/core/test_resources/pubspec_assets_snake_case.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   assets:
     outputs:

--- a/packages/core/test_resources/pubspec_assets_svg_integrations.yaml
+++ b/packages/core/test_resources/pubspec_assets_svg_integrations.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/
-  line_length: 80
 
   integrations:
     flutter_svg: true

--- a/packages/core/test_resources/pubspec_colors.yaml
+++ b/packages/core/test_resources/pubspec_colors.yaml
@@ -1,8 +1,10 @@
 name: test
 
+environment:
+  sdk: ^3.6.0
+
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   colors:
     inputs:

--- a/packages/core/test_resources/pubspec_colors_change_class_name.yaml
+++ b/packages/core/test_resources/pubspec_colors_change_class_name.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   colors:
     outputs:

--- a/packages/core/test_resources/pubspec_colors_no_inputs.yaml
+++ b/packages/core/test_resources/pubspec_colors_no_inputs.yaml
@@ -2,6 +2,5 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   colors:

--- a/packages/core/test_resources/pubspec_colors_no_inputs_list.yaml
+++ b/packages/core/test_resources/pubspec_colors_no_inputs_list.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   colors:
     inputs:

--- a/packages/core/test_resources/pubspec_fonts.yaml
+++ b/packages/core/test_resources/pubspec_fonts.yaml
@@ -1,8 +1,10 @@
 name: test
 
+environment:
+  sdk: ^3.6.0
+
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
 flutter:
   fonts:

--- a/packages/core/test_resources/pubspec_fonts_change_class_name.yaml
+++ b/packages/core/test_resources/pubspec_fonts_change_class_name.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   fonts:
     outputs:

--- a/packages/core/test_resources/pubspec_fonts_no_family.yaml
+++ b/packages/core/test_resources/pubspec_fonts_no_family.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
 flutter:
   fonts:

--- a/packages/core/test_resources/pubspec_fonts_package_parameter.yaml
+++ b/packages/core/test_resources/pubspec_fonts_package_parameter.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
   fonts:
     outputs:

--- a/packages/core/test_resources/pubspec_ignore_files.yaml
+++ b/packages/core/test_resources/pubspec_ignore_files.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
 flutter:
   assets:

--- a/packages/core/test_resources/pubspec_normal.yaml
+++ b/packages/core/test_resources/pubspec_normal.yaml
@@ -1,8 +1,10 @@
 name: example
 
+environment:
+  sdk: ^3.8.0
+
 flutter_gen:
   output: lib/gen/
-  line_length: 80
 
   integrations:
     flutter_svg: true

--- a/packages/core/test_resources/pubspec_only_flutter_gen_value.yaml
+++ b/packages/core/test_resources/pubspec_only_flutter_gen_value.yaml
@@ -2,7 +2,6 @@ name: example
 
 flutter_gen:
   output: lib/gen/
-  line_length: 80
 
   colors:
     inputs:

--- a/packages/core/test_resources/pubspec_unknown_mime_type.yaml
+++ b/packages/core/test_resources/pubspec_unknown_mime_type.yaml
@@ -2,7 +2,6 @@ name: test
 
 flutter_gen:
   output: lib/gen/ # Optional (default: lib/gen/)
-  line_length: 80 # Optional (default: 80)
 
 flutter:
   assets:

--- a/packages/core/test_resources/pubspec_wrong_output_path.yaml
+++ b/packages/core/test_resources/pubspec_wrong_output_path.yaml
@@ -2,7 +2,6 @@ name: example
 
 flutter_gen:
   output:
-  line_length: 80
 
   colors:
     inputs:


### PR DESCRIPTION
## What does this change?

Generated files are being formatted based on confusing conditions. The PR refactored how we construct the Dart formatter in a more elegant manner.

1. The formatter will try to find a valid Dart SDK constraint from `pubspec.yaml` / `pubspec.lock`. Otherwise, it will fall back to using the current Dart SDK version as the constraint. The behavior is like:
    1. When the user is using Dart SDK 3.8.0, `pubspec.yaml` has `^3.4.0`, and `pubspec.lock` resolves `^3.7.0`, the formatter will format like 3.4.0.
    2. When the runner is being used for testing purposes, which the specified pubspec file does not contain `environment - sdk` (and likely does not have a `pubspec.lock`), the formatter will format based on the current Dart SDK version.
2. The formatter will try to find a valid page width from `analysis_options.yaml - formatter - page_width` / `pubspec.yaml - flutter_gen - line_length`, then prepend the format width header to make all format tools respect the config.

- Fixes https://github.com/FlutterGen/flutter_gen/pull/685#issuecomment-3072878805
- Fixes https://github.com/FlutterGen/flutter_gen/pull/659#issuecomment-2671623506
- Fixes https://github.com/FlutterGen/flutter_gen/pull/620

## Type of change

- [x] New feature (non-breaking change which adds functionality)