### PR TITLE
Allow build 3.0.0

### DIFF
--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   flutter_gen_core: 5.10.0
-  build: ^2.0.0
+  build: '>=2.0.0 <4.0.0'
   collection: ^1.17.0
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
## What does this change?

Allow `build 3.0.0`.

Fixes #690 

## Type of change

Should be a no-op: just allow users to use `build 3.0.0` which will be required for other builders, but not this one.