### PR TITLE
refactor: use `abstract final` class for generated classes

### DIFF
--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -221,7 +221,6 @@ class $AssetsLottieWrongGen {
 }
 
 abstract final class MyAssets {
-
   static const String readme = 'README.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/examples/example/lib/gen/assets.gen.dart
+++ b/examples/example/lib/gen/assets.gen.dart
@@ -220,8 +220,7 @@ class $AssetsLottieWrongGen {
   List<String> get values => [dummy, rocketLottieV439];
 }
 
-class MyAssets {
-  const MyAssets._();
+abstract final class MyAssets {
 
   static const String readme = 'README.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();

--- a/examples/example/lib/gen/colors.gen.dart
+++ b/examples/example/lib/gen/colors.gen.dart
@@ -11,8 +11,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
-class MyColorName {
-  const MyColorName._();
+abstract final class MyColorName {
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/examples/example/lib/gen/colors.gen.dart
+++ b/examples/example/lib/gen/colors.gen.dart
@@ -12,7 +12,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 class MyColorName {
-  MyColorName._();
+  const MyColorName._();
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/examples/example/lib/gen/colors.gen.dart
+++ b/examples/example/lib/gen/colors.gen.dart
@@ -12,7 +12,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 abstract final class MyColorName {
-
   /// Color: #000000
   static const Color black = Color(0xFF000000);
 

--- a/examples/example/lib/gen/fonts.gen.dart
+++ b/examples/example/lib/gen/fonts.gen.dart
@@ -9,7 +9,6 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 abstract final class MyFontFamily {
-
   /// Font family: Raleway
   static const String raleway = 'Raleway';
 

--- a/examples/example/lib/gen/fonts.gen.dart
+++ b/examples/example/lib/gen/fonts.gen.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class MyFontFamily {
-  const MyFontFamily._();
+abstract final class MyFontFamily {
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/examples/example/lib/gen/fonts.gen.dart
+++ b/examples/example/lib/gen/fonts.gen.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class MyFontFamily {
-  MyFontFamily._();
+  const MyFontFamily._();
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -56,8 +56,7 @@ class $AssetsUnknownGen {
   List<String> get values => [unknownMimeType];
 }
 
-class ResAssets {
-  const ResAssets._();
+abstract final class ResAssets {
 
   static const String package = 'example_resources';
 

--- a/examples/example_resources/lib/gen/assets.gen.dart
+++ b/examples/example_resources/lib/gen/assets.gen.dart
@@ -57,7 +57,6 @@ class $AssetsUnknownGen {
 }
 
 abstract final class ResAssets {
-
   static const String package = 'example_resources';
 
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/examples/example_resources/lib/gen/colors.gen.dart
+++ b/examples/example_resources/lib/gen/colors.gen.dart
@@ -12,7 +12,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 abstract final class ColorName {
-
   /// Color: #000000
   static const Color black = Color(0xFF000000);
 

--- a/examples/example_resources/lib/gen/colors.gen.dart
+++ b/examples/example_resources/lib/gen/colors.gen.dart
@@ -12,7 +12,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 class ColorName {
-  ColorName._();
+  const ColorName._();
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/examples/example_resources/lib/gen/colors.gen.dart
+++ b/examples/example_resources/lib/gen/colors.gen.dart
@@ -11,8 +11,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
-class ColorName {
-  const ColorName._();
+abstract final class ColorName {
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/examples/example_workspace/packages/gallery_one/lib/gen/assets.gen.dart
+++ b/examples/example_workspace/packages/gallery_one/lib/gen/assets.gen.dart
@@ -22,8 +22,7 @@ class $AssetsImagesGen {
   List<AssetGenImage> get values => [flutter3];
 }
 
-class GalleryOneAssets {
-  const GalleryOneAssets._();
+abstract final class GalleryOneAssets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }

--- a/examples/example_workspace/packages/gallery_one/lib/gen/assets.gen.dart
+++ b/examples/example_workspace/packages/gallery_one/lib/gen/assets.gen.dart
@@ -23,7 +23,6 @@ class $AssetsImagesGen {
 }
 
 abstract final class GalleryOneAssets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 

--- a/examples/example_workspace/packages/gallery_two/lib/gen/assets.gen.dart
+++ b/examples/example_workspace/packages/gallery_two/lib/gen/assets.gen.dart
@@ -20,6 +20,5 @@ class $AssetsImagesGen {
 }
 
 abstract final class GalleryTwoAssets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }

--- a/examples/example_workspace/packages/gallery_two/lib/gen/assets.gen.dart
+++ b/examples/example_workspace/packages/gallery_two/lib/gen/assets.gen.dart
@@ -19,8 +19,7 @@ class $AssetsImagesGen {
   List<String> get values => [dart];
 }
 
-class GalleryTwoAssets {
-  const GalleryTwoAssets._();
+abstract final class GalleryTwoAssets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }

--- a/melos.yaml
+++ b/melos.yaml
@@ -33,7 +33,11 @@ scripts:
 
   format:
     run: |
-      dart format --set-exit-if-changed .
+      find . -name "*.dart" \
+        -not -path "*/actual_data/*" \
+        -not -path "*/.dart_tool/*" \
+        -not -path "*/build/*" \
+        -print0 | xargs -0 dart format --set-exit-if-changed
       git --no-pager diff --exit-code
     description: Format Dart files and exit if unstaged changes exist
 

--- a/packages/core/lib/generators/assets_generator.dart
+++ b/packages/core/lib/generators/assets_generator.dart
@@ -592,8 +592,7 @@ String _assetsClassDefinition(
   String? packageName,
 ) {
   return '''
-class $className {
-  const $className._();
+abstract final class $className {
 ${packageName != null ? "\n  static const String package = '$packageName';" : ''}
 
   $statementsBlock

--- a/packages/core/lib/generators/colors_generator.dart
+++ b/packages/core/lib/generators/colors_generator.dart
@@ -30,8 +30,7 @@ String generateColors(
   buffer.writeln("import 'package:flutter/painting.dart';");
   buffer.writeln("import 'package:flutter/material.dart';");
   buffer.writeln();
-  buffer.writeln('class $className {');
-  buffer.writeln('const $className._();');
+  buffer.writeln('abstract final class $className {');
   buffer.writeln();
 
   final colorList = <_Color>[];

--- a/packages/core/lib/generators/colors_generator.dart
+++ b/packages/core/lib/generators/colors_generator.dart
@@ -31,7 +31,7 @@ String generateColors(
   buffer.writeln("import 'package:flutter/material.dart';");
   buffer.writeln();
   buffer.writeln('class $className {');
-  buffer.writeln('$className._();');
+  buffer.writeln('const $className._();');
   buffer.writeln();
 
   final colorList = <_Color>[];

--- a/packages/core/lib/generators/fonts_generator.dart
+++ b/packages/core/lib/generators/fonts_generator.dart
@@ -49,7 +49,7 @@ String generateFonts(
   buffer.writeln(header);
   buffer.writeln(ignore);
   buffer.writeln('class $className {');
-  buffer.writeln('$className._();');
+  buffer.writeln('const $className._();');
   buffer.writeln();
 
   final isPackage = config.packageParameterLiteral.isNotEmpty;

--- a/packages/core/lib/generators/fonts_generator.dart
+++ b/packages/core/lib/generators/fonts_generator.dart
@@ -48,8 +48,7 @@ String generateFonts(
   buffer.writeln('// dart format width=${formatter.pageWidth}');
   buffer.writeln(header);
   buffer.writeln(ignore);
-  buffer.writeln('class $className {');
-  buffer.writeln('const $className._();');
+  buffer.writeln('abstract final class $className {');
   buffer.writeln();
 
   final isPackage = config.packageParameterLiteral.isNotEmpty;

--- a/packages/core/test_resources/actual_data/assets_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets.gen.dart
@@ -145,7 +145,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/assets_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets.gen.dart
@@ -144,8 +144,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();

--- a/packages/core/test_resources/actual_data/assets_assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_camel_case.gen.dart
@@ -11,8 +11,7 @@
 
 import 'package:flutter/widgets.dart';
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   /// File path: assets/images/chip1.jpg
   static const AssetGenImage imagesChip1 = AssetGenImage(
@@ -74,21 +73,21 @@ class Assets {
 
   /// List of all assets
   static List<dynamic> get values => [
-    imagesChip1,
-    imagesChip2,
-    imagesChip3Chip3,
-    imagesChip4Chip4,
-    imagesIconsDartTest,
-    imagesIconsFuchsia,
-    imagesIconsKmm,
-    imagesIconsPaint,
-    imagesLogo,
-    imagesProfileJpg,
-    imagesProfilePng,
-    jsonList,
-    jsonMap,
-    picturesChip5,
-  ];
+        imagesChip1,
+        imagesChip2,
+        imagesChip3Chip3,
+        imagesChip4Chip4,
+        imagesIconsDartTest,
+        imagesIconsFuchsia,
+        imagesIconsKmm,
+        imagesIconsPaint,
+        imagesLogo,
+        imagesProfileJpg,
+        imagesProfilePng,
+        jsonList,
+        jsonMap,
+        picturesChip5,
+      ];
 }
 
 class AssetGenImage {

--- a/packages/core/test_resources/actual_data/assets_assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_camel_case.gen.dart
@@ -12,7 +12,6 @@
 import 'package:flutter/widgets.dart';
 
 abstract final class Assets {
-
   /// File path: assets/images/chip1.jpg
   static const AssetGenImage imagesChip1 = AssetGenImage(
     'assets/images/chip1.jpg',

--- a/packages/core/test_resources/actual_data/assets_assets_camel_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_camel_case.gen.dart
@@ -72,21 +72,21 @@ abstract final class Assets {
 
   /// List of all assets
   static List<dynamic> get values => [
-        imagesChip1,
-        imagesChip2,
-        imagesChip3Chip3,
-        imagesChip4Chip4,
-        imagesIconsDartTest,
-        imagesIconsFuchsia,
-        imagesIconsKmm,
-        imagesIconsPaint,
-        imagesLogo,
-        imagesProfileJpg,
-        imagesProfilePng,
-        jsonList,
-        jsonMap,
-        picturesChip5,
-      ];
+    imagesChip1,
+    imagesChip2,
+    imagesChip3Chip3,
+    imagesChip4Chip4,
+    imagesIconsDartTest,
+    imagesIconsFuchsia,
+    imagesIconsKmm,
+    imagesIconsPaint,
+    imagesLogo,
+    imagesProfileJpg,
+    imagesProfilePng,
+    jsonList,
+    jsonMap,
+    picturesChip5,
+  ];
 }
 
 class AssetGenImage {

--- a/packages/core/test_resources/actual_data/assets_assets_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_change_class_name.gen.dart
@@ -42,7 +42,6 @@ class $AssetsImagesGen {
 }
 
 abstract final class MyAssets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_assets_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_change_class_name.gen.dart
@@ -33,16 +33,15 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
-class MyAssets {
-  const MyAssets._();
+abstract final class MyAssets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }

--- a/packages/core/test_resources/actual_data/assets_assets_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_change_class_name.gen.dart
@@ -33,12 +33,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 abstract final class MyAssets {

--- a/packages/core/test_resources/actual_data/assets_assets_deferred_components.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_deferred_components.gen.dart
@@ -79,12 +79,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
 class $AssetsJsonGen {
@@ -129,8 +129,8 @@ class $AssetsDeferredComponentImagesGen {
 
   /// File path: assets/deferred_component/images/component_logo.png
   AssetGenImage get componentLogo => const AssetGenImage(
-    'assets/deferred_component/images/component_logo.png',
-  );
+        'assets/deferred_component/images/component_logo.png',
+      );
 
   /// List of all assets
   List<AssetGenImage> get values => [chip1, componentLogo];
@@ -201,8 +201,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsDeferredComponentGen deferredComponent =
@@ -308,10 +307,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -367,8 +366,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_deferred_components.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_deferred_components.gen.dart
@@ -79,12 +79,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {
@@ -129,8 +129,8 @@ class $AssetsDeferredComponentImagesGen {
 
   /// File path: assets/deferred_component/images/component_logo.png
   AssetGenImage get componentLogo => const AssetGenImage(
-        'assets/deferred_component/images/component_logo.png',
-      );
+    'assets/deferred_component/images/component_logo.png',
+  );
 
   /// List of all assets
   List<AssetGenImage> get values => [chip1, componentLogo];
@@ -306,10 +306,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -365,7 +365,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_deferred_components.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_deferred_components.gen.dart
@@ -202,7 +202,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsDeferredComponentGen deferredComponent =
       $AssetsDeferredComponentGen();

--- a/packages/core/test_resources/actual_data/assets_assets_directory_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_directory_path.gen.dart
@@ -72,8 +72,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
@@ -169,10 +168,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -228,8 +227,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_directory_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_directory_path.gen.dart
@@ -73,7 +73,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }

--- a/packages/core/test_resources/actual_data/assets_assets_directory_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_directory_path.gen.dart
@@ -167,10 +167,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -226,7 +226,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_directory_path_with_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_directory_path_with_package_parameter.gen.dart
@@ -177,10 +177,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -239,7 +239,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_directory_path_with_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_directory_path_with_package_parameter.gen.dart
@@ -74,7 +74,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String package = 'test';
 
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/assets_assets_directory_path_with_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_directory_path_with_package_parameter.gen.dart
@@ -73,8 +73,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String package = 'test';
 
@@ -179,10 +178,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -241,8 +240,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_exclude_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_exclude_files.gen.dart
@@ -65,7 +65,6 @@ class $AssetsImagesChip4Gen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
   static const $PicturesGen pictures = $PicturesGen();

--- a/packages/core/test_resources/actual_data/assets_assets_exclude_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_exclude_files.gen.dart
@@ -64,8 +64,7 @@ class $AssetsImagesChip4Gen {
   List<AssetGenImage> get values => [chip4];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();

--- a/packages/core/test_resources/actual_data/assets_assets_flavored.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_flavored.gen.dart
@@ -150,7 +150,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/assets_assets_flavored.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_flavored.gen.dart
@@ -65,12 +65,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {
@@ -252,10 +252,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -311,7 +311,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_flavored.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_flavored.gen.dart
@@ -65,12 +65,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
 class $AssetsJsonGen {
@@ -149,8 +149,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();
@@ -254,10 +253,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -313,8 +312,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_lottie_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_lottie_integrations.gen.dart
@@ -33,11 +33,11 @@ class $AssetsLottieGen {
 
   /// List of all assets
   List<LottieGenImage> get values => [
-        xuiIZ9X1Rf,
-        catCat,
-        hamburgerArrow,
-        spinningCarrousel,
-      ];
+    xuiIZ9X1Rf,
+    catCat,
+    hamburgerArrow,
+    spinningCarrousel,
+  ];
 }
 
 abstract final class Assets {
@@ -63,7 +63,7 @@ class LottieGenImage {
     Key? key,
     AssetBundle? bundle,
     Widget Function(BuildContext, Widget, _lottie.LottieComposition?)?
-        frameBuilder,
+    frameBuilder,
     ImageErrorWidgetBuilder? errorBuilder,
     double? width,
     double? height,

--- a/packages/core/test_resources/actual_data/assets_assets_lottie_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_lottie_integrations.gen.dart
@@ -41,7 +41,6 @@ class $AssetsLottieGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsLottieGen lottie = $AssetsLottieGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_assets_lottie_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_lottie_integrations.gen.dart
@@ -33,15 +33,14 @@ class $AssetsLottieGen {
 
   /// List of all assets
   List<LottieGenImage> get values => [
-    xuiIZ9X1Rf,
-    catCat,
-    hamburgerArrow,
-    spinningCarrousel,
-  ];
+        xuiIZ9X1Rf,
+        catCat,
+        hamburgerArrow,
+        spinningCarrousel,
+      ];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsLottieGen lottie = $AssetsLottieGen();
 }
@@ -65,7 +64,7 @@ class LottieGenImage {
     Key? key,
     AssetBundle? bundle,
     Widget Function(BuildContext, Widget, _lottie.LottieComposition?)?
-    frameBuilder,
+        frameBuilder,
     ImageErrorWidgetBuilder? errorBuilder,
     double? width,
     double? height,

--- a/packages/core/test_resources/actual_data/assets_assets_no_image_integration.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_no_image_integration.gen.dart
@@ -102,8 +102,7 @@ class $AssetsImagesIconsGen {
   List<String> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();

--- a/packages/core/test_resources/actual_data/assets_assets_no_image_integration.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_no_image_integration.gen.dart
@@ -103,7 +103,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
   static const $PicturesGen pictures = $PicturesGen();

--- a/packages/core/test_resources/actual_data/assets_assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_no_integrations.gen.dart
@@ -52,12 +52,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {

--- a/packages/core/test_resources/actual_data/assets_assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_no_integrations.gen.dart
@@ -115,7 +115,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
   static const $PicturesGen pictures = $PicturesGen();

--- a/packages/core/test_resources/actual_data/assets_assets_no_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_no_integrations.gen.dart
@@ -52,12 +52,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
 class $AssetsJsonGen {
@@ -114,8 +114,7 @@ class $AssetsImagesIconsGen {
   List<String> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();

--- a/packages/core/test_resources/actual_data/assets_assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_package_parameter.gen.dart
@@ -61,8 +61,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String package = 'test';
 
@@ -167,10 +166,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -229,8 +228,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_package_parameter.gen.dart
@@ -165,10 +165,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -227,7 +227,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_package_parameter.gen.dart
@@ -62,7 +62,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String package = 'test';
 
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/assets_assets_package_parameter_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_package_parameter_disable_null_safety.gen.dart
@@ -153,10 +153,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -215,7 +215,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_package_parameter_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_package_parameter_disable_null_safety.gen.dart
@@ -51,7 +51,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String package = 'test';
 
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/assets_assets_package_parameter_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_package_parameter_disable_null_safety.gen.dart
@@ -50,8 +50,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String package = 'test';
 
@@ -155,10 +154,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -217,8 +216,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_parse_metadata.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_parse_metadata.gen.dart
@@ -43,9 +43,9 @@ class $AssetsImagesGen {
 
   /// File path: assets/images/chip1.jpg
   AssetGenImage get chip1 => const AssetGenImage(
-    'assets/images/chip1.jpg',
-    size: const Size(600.0, 403.0),
-  );
+        'assets/images/chip1.jpg',
+        size: const Size(600.0, 403.0),
+      );
 
   /// File path: assets/images/chip2.jpg
   AssetGenImage get chip2 => const AssetGenImage('assets/images/chip2.jpg');
@@ -61,9 +61,9 @@ class $AssetsImagesGen {
 
   /// File path: assets/images/logo.png
   AssetGenImage get logo => const AssetGenImage(
-    'assets/images/logo.png',
-    size: const Size(209.0, 49.0),
-  );
+        'assets/images/logo.png',
+        size: const Size(209.0, 49.0),
+      );
 
   /// File path: assets/images/profile.jpg
   AssetGenImage get profileJpg =>
@@ -75,12 +75,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
 class $AssetsJsonGen {
@@ -121,14 +121,14 @@ class $AssetsImagesAnimatedGen {
 
   /// File path: assets/images/animated/emoji_hugging_face.webp
   AssetGenImage get emojiHuggingFace => const AssetGenImage(
-    'assets/images/animated/emoji_hugging_face.webp',
-    size: const Size(512.0, 512.0),
-    animation: const AssetGenImageAnimation(
-      isAnimation: true,
-      duration: Duration(milliseconds: 2970),
-      frames: 45,
-    ),
-  );
+        'assets/images/animated/emoji_hugging_face.webp',
+        size: const Size(512.0, 512.0),
+        animation: const AssetGenImageAnimation(
+          isAnimation: true,
+          duration: Duration(milliseconds: 2970),
+          frames: 45,
+        ),
+      );
 
   /// List of all assets
   List<AssetGenImage> get values => [emojiHuggingFace];
@@ -139,9 +139,9 @@ class $AssetsImagesChip3Gen {
 
   /// File path: assets/images/chip3/chip3.jpg
   AssetGenImage get chip3 => const AssetGenImage(
-    'assets/images/chip3/chip3.jpg',
-    size: const Size(600.0, 403.0),
-  );
+        'assets/images/chip3/chip3.jpg',
+        size: const Size(600.0, 403.0),
+      );
 
   /// List of all assets
   List<AssetGenImage> get values => [chip3];
@@ -152,9 +152,9 @@ class $AssetsImagesChip4Gen {
 
   /// File path: assets/images/chip4/chip4.jpg
   AssetGenImage get chip4 => const AssetGenImage(
-    'assets/images/chip4/chip4.jpg',
-    size: const Size(600.0, 403.0),
-  );
+        'assets/images/chip4/chip4.jpg',
+        size: const Size(600.0, 403.0),
+      );
 
   /// List of all assets
   List<AssetGenImage> get values => [chip4];
@@ -165,15 +165,15 @@ class $AssetsImagesIconsGen {
 
   /// File path: assets/images/icons/dart@test.svg
   SvgGenImage get dartTest => const SvgGenImage(
-    'assets/images/icons/dart@test.svg',
-    size: Size(512.001, 512.001),
-  );
+        'assets/images/icons/dart@test.svg',
+        size: Size(512.001, 512.001),
+      );
 
   /// File path: assets/images/icons/fuchsia.svg
   SvgGenImage get fuchsia => const SvgGenImage(
-    'assets/images/icons/fuchsia.svg',
-    size: Size(50.0, 50.0),
-  );
+        'assets/images/icons/fuchsia.svg',
+        size: Size(50.0, 50.0),
+      );
 
   /// File path: assets/images/icons/invalid.svg
   SvgGenImage get invalid =>
@@ -181,22 +181,21 @@ class $AssetsImagesIconsGen {
 
   /// File path: assets/images/icons/kmm.svg
   SvgGenImage get kmm => const SvgGenImage(
-    'assets/images/icons/kmm.svg',
-    size: Size(755.0, 310.0),
-  );
+        'assets/images/icons/kmm.svg',
+        size: Size(755.0, 310.0),
+      );
 
   /// File path: assets/images/icons/paint.svg
   SvgGenImage get paint => const SvgGenImage(
-    'assets/images/icons/paint.svg',
-    size: Size(472.0, 392.0),
-  );
+        'assets/images/icons/paint.svg',
+        size: Size(472.0, 392.0),
+      );
 
   /// List of all assets
   List<SvgGenImage> get values => [dartTest, fuchsia, invalid, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
@@ -296,10 +295,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -355,8 +354,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_parse_metadata.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_parse_metadata.gen.dart
@@ -43,9 +43,9 @@ class $AssetsImagesGen {
 
   /// File path: assets/images/chip1.jpg
   AssetGenImage get chip1 => const AssetGenImage(
-        'assets/images/chip1.jpg',
-        size: const Size(600.0, 403.0),
-      );
+    'assets/images/chip1.jpg',
+    size: const Size(600.0, 403.0),
+  );
 
   /// File path: assets/images/chip2.jpg
   AssetGenImage get chip2 => const AssetGenImage('assets/images/chip2.jpg');
@@ -61,9 +61,9 @@ class $AssetsImagesGen {
 
   /// File path: assets/images/logo.png
   AssetGenImage get logo => const AssetGenImage(
-        'assets/images/logo.png',
-        size: const Size(209.0, 49.0),
-      );
+    'assets/images/logo.png',
+    size: const Size(209.0, 49.0),
+  );
 
   /// File path: assets/images/profile.jpg
   AssetGenImage get profileJpg =>
@@ -75,12 +75,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {
@@ -121,14 +121,14 @@ class $AssetsImagesAnimatedGen {
 
   /// File path: assets/images/animated/emoji_hugging_face.webp
   AssetGenImage get emojiHuggingFace => const AssetGenImage(
-        'assets/images/animated/emoji_hugging_face.webp',
-        size: const Size(512.0, 512.0),
-        animation: const AssetGenImageAnimation(
-          isAnimation: true,
-          duration: Duration(milliseconds: 2970),
-          frames: 45,
-        ),
-      );
+    'assets/images/animated/emoji_hugging_face.webp',
+    size: const Size(512.0, 512.0),
+    animation: const AssetGenImageAnimation(
+      isAnimation: true,
+      duration: Duration(milliseconds: 2970),
+      frames: 45,
+    ),
+  );
 
   /// List of all assets
   List<AssetGenImage> get values => [emojiHuggingFace];
@@ -139,9 +139,9 @@ class $AssetsImagesChip3Gen {
 
   /// File path: assets/images/chip3/chip3.jpg
   AssetGenImage get chip3 => const AssetGenImage(
-        'assets/images/chip3/chip3.jpg',
-        size: const Size(600.0, 403.0),
-      );
+    'assets/images/chip3/chip3.jpg',
+    size: const Size(600.0, 403.0),
+  );
 
   /// List of all assets
   List<AssetGenImage> get values => [chip3];
@@ -152,9 +152,9 @@ class $AssetsImagesChip4Gen {
 
   /// File path: assets/images/chip4/chip4.jpg
   AssetGenImage get chip4 => const AssetGenImage(
-        'assets/images/chip4/chip4.jpg',
-        size: const Size(600.0, 403.0),
-      );
+    'assets/images/chip4/chip4.jpg',
+    size: const Size(600.0, 403.0),
+  );
 
   /// List of all assets
   List<AssetGenImage> get values => [chip4];
@@ -165,15 +165,15 @@ class $AssetsImagesIconsGen {
 
   /// File path: assets/images/icons/dart@test.svg
   SvgGenImage get dartTest => const SvgGenImage(
-        'assets/images/icons/dart@test.svg',
-        size: Size(512.001, 512.001),
-      );
+    'assets/images/icons/dart@test.svg',
+    size: Size(512.001, 512.001),
+  );
 
   /// File path: assets/images/icons/fuchsia.svg
   SvgGenImage get fuchsia => const SvgGenImage(
-        'assets/images/icons/fuchsia.svg',
-        size: Size(50.0, 50.0),
-      );
+    'assets/images/icons/fuchsia.svg',
+    size: Size(50.0, 50.0),
+  );
 
   /// File path: assets/images/icons/invalid.svg
   SvgGenImage get invalid =>
@@ -181,15 +181,15 @@ class $AssetsImagesIconsGen {
 
   /// File path: assets/images/icons/kmm.svg
   SvgGenImage get kmm => const SvgGenImage(
-        'assets/images/icons/kmm.svg',
-        size: Size(755.0, 310.0),
-      );
+    'assets/images/icons/kmm.svg',
+    size: Size(755.0, 310.0),
+  );
 
   /// File path: assets/images/icons/paint.svg
   SvgGenImage get paint => const SvgGenImage(
-        'assets/images/icons/paint.svg',
-        size: Size(472.0, 392.0),
-      );
+    'assets/images/icons/paint.svg',
+    size: Size(472.0, 392.0),
+  );
 
   /// List of all assets
   List<SvgGenImage> get values => [dartTest, fuchsia, invalid, kmm, paint];
@@ -294,10 +294,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -353,7 +353,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_parse_metadata.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_parse_metadata.gen.dart
@@ -196,7 +196,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();

--- a/packages/core/test_resources/actual_data/assets_assets_rive_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_rive_integrations.gen.dart
@@ -22,8 +22,7 @@ class $AssetsRiveGen {
   List<RiveGenImage> get values => [vehicles];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsRiveGen rive = $AssetsRiveGen();
 }

--- a/packages/core/test_resources/actual_data/assets_assets_rive_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_rive_integrations.gen.dart
@@ -23,7 +23,6 @@ class $AssetsRiveGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsRiveGen rive = $AssetsRiveGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_snake_case.gen.dart
@@ -11,8 +11,7 @@
 
 import 'package:flutter/widgets.dart';
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   /// File path: assets/images/chip1.jpg
   static const AssetGenImage images_chip1 = AssetGenImage(
@@ -75,21 +74,21 @@ class Assets {
 
   /// List of all assets
   static List<dynamic> get values => [
-    images_chip1,
-    images_chip2,
-    images_chip3_chip3,
-    images_chip4_chip4,
-    images_icons_dart_test,
-    images_icons_fuchsia,
-    images_icons_kmm,
-    images_icons_paint,
-    images_logo,
-    images_profile_jpg,
-    images_profile_png,
-    json_list,
-    json_map,
-    pictures_chip5,
-  ];
+        images_chip1,
+        images_chip2,
+        images_chip3_chip3,
+        images_chip4_chip4,
+        images_icons_dart_test,
+        images_icons_fuchsia,
+        images_icons_kmm,
+        images_icons_paint,
+        images_logo,
+        images_profile_jpg,
+        images_profile_png,
+        json_list,
+        json_map,
+        pictures_chip5,
+      ];
 }
 
 class AssetGenImage {

--- a/packages/core/test_resources/actual_data/assets_assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_snake_case.gen.dart
@@ -73,21 +73,21 @@ abstract final class Assets {
 
   /// List of all assets
   static List<dynamic> get values => [
-        images_chip1,
-        images_chip2,
-        images_chip3_chip3,
-        images_chip4_chip4,
-        images_icons_dart_test,
-        images_icons_fuchsia,
-        images_icons_kmm,
-        images_icons_paint,
-        images_logo,
-        images_profile_jpg,
-        images_profile_png,
-        json_list,
-        json_map,
-        pictures_chip5,
-      ];
+    images_chip1,
+    images_chip2,
+    images_chip3_chip3,
+    images_chip4_chip4,
+    images_icons_dart_test,
+    images_icons_fuchsia,
+    images_icons_kmm,
+    images_icons_paint,
+    images_logo,
+    images_profile_jpg,
+    images_profile_png,
+    json_list,
+    json_map,
+    pictures_chip5,
+  ];
 }
 
 class AssetGenImage {

--- a/packages/core/test_resources/actual_data/assets_assets_snake_case.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_snake_case.gen.dart
@@ -12,7 +12,6 @@
 import 'package:flutter/widgets.dart';
 
 abstract final class Assets {
-
   /// File path: assets/images/chip1.jpg
   static const AssetGenImage images_chip1 = AssetGenImage(
     'assets/images/chip1.jpg',

--- a/packages/core/test_resources/actual_data/assets_assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_svg_integrations.gen.dart
@@ -40,7 +40,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_svg_integrations.gen.dart
@@ -45,10 +45,10 @@ abstract final class Assets {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -104,7 +104,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_assets_svg_integrations.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_assets_svg_integrations.gen.dart
@@ -39,18 +39,17 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia, kmm];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -106,8 +105,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_change_output_path.gen.dart
@@ -42,7 +42,6 @@ class $AssetsImagesGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_change_output_path.gen.dart
@@ -33,12 +33,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 abstract final class Assets {

--- a/packages/core/test_resources/actual_data/assets_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_change_output_path.gen.dart
@@ -33,16 +33,15 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }

--- a/packages/core/test_resources/actual_data/assets_exclude_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_exclude_files.gen.dart
@@ -62,8 +62,7 @@ class $AssetsImagesChip4Gen {
   List<AssetGenImage> get values => [chip4];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();

--- a/packages/core/test_resources/actual_data/assets_exclude_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_exclude_files.gen.dart
@@ -63,7 +63,6 @@ class $AssetsImagesChip4Gen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
   static const $PicturesGen pictures = $PicturesGen();

--- a/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
@@ -14,6 +14,5 @@ class $AssetsUnknownGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }

--- a/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_ignore_files.gen.dart
@@ -13,8 +13,7 @@ class $AssetsUnknownGen {
   const $AssetsUnknownGen();
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }

--- a/packages/core/test_resources/actual_data/assets_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_normal.gen.dart
@@ -120,7 +120,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
   static const $PicturesGen pictures = $PicturesGen();

--- a/packages/core/test_resources/actual_data/assets_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_normal.gen.dart
@@ -55,12 +55,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 class $AssetsJsonGen {
@@ -215,10 +215,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = false;
+    : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-      : _isVecFormat = true;
+    : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -274,7 +274,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
+      colorFilter:
+          colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_normal.gen.dart
@@ -55,12 +55,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
 class $AssetsJsonGen {
@@ -119,8 +119,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonGen json = $AssetsJsonGen();
@@ -217,10 +216,10 @@ class AssetGenImageAnimation {
 
 class SvgGenImage {
   const SvgGenImage(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = false;
+      : _isVecFormat = false;
 
   const SvgGenImage.vec(this._assetName, {this.size, this.flavors = const {}})
-    : _isVecFormat = true;
+      : _isVecFormat = true;
 
   final String _assetName;
   final Size? size;
@@ -276,8 +275,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter:
-          colorFilter ??
+      colorFilter: colorFilter ??
           (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,

--- a/packages/core/test_resources/actual_data/assets_only_flutter_value.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_only_flutter_value.gen.dart
@@ -42,7 +42,6 @@ class $AssetsImagesGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_only_flutter_value.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_only_flutter_value.gen.dart
@@ -33,12 +33,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 abstract final class Assets {

--- a/packages/core/test_resources/actual_data/assets_only_flutter_value.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_only_flutter_value.gen.dart
@@ -33,16 +33,15 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }

--- a/packages/core/test_resources/actual_data/assets_package_parameter_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter_disable_null_safety.gen.dart
@@ -48,8 +48,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String package = 'test';
 

--- a/packages/core/test_resources/actual_data/assets_package_parameter_disable_null_safety.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_package_parameter_disable_null_safety.gen.dart
@@ -49,7 +49,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String package = 'test';
 
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
@@ -19,8 +19,7 @@ class $AssetsUnknownGen {
   List<String> get values => [unknownMimeType];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }

--- a/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_unknown_mime_type.gen.dart
@@ -20,6 +20,5 @@ class $AssetsUnknownGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsUnknownGen unknown = $AssetsUnknownGen();
 }

--- a/packages/core/test_resources/actual_data/assets_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_wrong_output_path.gen.dart
@@ -42,7 +42,6 @@ class $AssetsImagesGen {
 }
 
 abstract final class Assets {
-
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }
 

--- a/packages/core/test_resources/actual_data/assets_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_wrong_output_path.gen.dart
@@ -33,12 +33,12 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-        chip1,
-        chip2,
-        logo,
-        profileJpg,
-        profilePng,
-      ];
+    chip1,
+    chip2,
+    logo,
+    profileJpg,
+    profilePng,
+  ];
 }
 
 abstract final class Assets {

--- a/packages/core/test_resources/actual_data/assets_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/assets_wrong_output_path.gen.dart
@@ -33,16 +33,15 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<AssetGenImage> get values => [
-    chip1,
-    chip2,
-    logo,
-    profileJpg,
-    profilePng,
-  ];
+        chip1,
+        chip2,
+        logo,
+        profileJpg,
+        profilePng,
+      ];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const $AssetsImagesGen images = $AssetsImagesGen();
 }

--- a/packages/core/test_resources/actual_data/build_assets_build_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_assets.gen.dart
@@ -145,7 +145,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/build_assets_build_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_assets.gen.dart
@@ -144,8 +144,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();

--- a/packages/core/test_resources/actual_data/build_assets_build_empty.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_empty.gen.dart
@@ -145,7 +145,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class Assets {
-
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/build_assets_build_empty.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_empty.gen.dart
@@ -144,8 +144,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class Assets {
-  const Assets._();
+abstract final class Assets {
 
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();

--- a/packages/core/test_resources/actual_data/build_assets_build_runner_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_runner_assets.gen.dart
@@ -56,13 +56,16 @@ class $AssetsImagesGen {
   AssetGenImage get logo => const AssetGenImage('assets/images/logo.png');
 
   /// File path: assets/images/profile.jpg
-  AssetGenImage get profileJpg => const AssetGenImage('assets/images/profile.jpg');
+  AssetGenImage get profileJpg =>
+      const AssetGenImage('assets/images/profile.jpg');
 
   /// File path: assets/images/profile.png
-  AssetGenImage get profilePng => const AssetGenImage('assets/images/profile.png');
+  AssetGenImage get profilePng =>
+      const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values => [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values =>
+      [chip1, chip2, logo, profileJpg, profilePng];
 }
 
 class $AssetsJsonGen {
@@ -102,7 +105,8 @@ class $AssetsImagesChip3Gen {
   const $AssetsImagesChip3Gen();
 
   /// File path: assets/images/chip3/chip3.jpg
-  AssetGenImage get chip3 => const AssetGenImage('assets/images/chip3/chip3.jpg');
+  AssetGenImage get chip3 =>
+      const AssetGenImage('assets/images/chip3/chip3.jpg');
 
   /// List of all assets
   List<AssetGenImage> get values => [chip3];
@@ -112,7 +116,8 @@ class $AssetsImagesChip4Gen {
   const $AssetsImagesChip4Gen();
 
   /// File path: assets/images/chip4/chip4.jpg
-  AssetGenImage get chip4 => const AssetGenImage('assets/images/chip4/chip4.jpg');
+  AssetGenImage get chip4 =>
+      const AssetGenImage('assets/images/chip4/chip4.jpg');
 
   /// List of all assets
   List<AssetGenImage> get values => [chip4];
@@ -122,10 +127,12 @@ class $AssetsImagesIconsGen {
   const $AssetsImagesIconsGen();
 
   /// File path: assets/images/icons/dart@test.svg
-  SvgGenImage get dartTest => const SvgGenImage('assets/images/icons/dart@test.svg');
+  SvgGenImage get dartTest =>
+      const SvgGenImage('assets/images/icons/dart@test.svg');
 
   /// File path: assets/images/icons/fuchsia.svg
-  SvgGenImage get fuchsia => const SvgGenImage('assets/images/icons/fuchsia.svg');
+  SvgGenImage get fuchsia =>
+      const SvgGenImage('assets/images/icons/fuchsia.svg');
 
   /// File path: assets/images/icons/kmm.svg
   SvgGenImage get kmm => const SvgGenImage('assets/images/icons/kmm.svg');
@@ -137,8 +144,7 @@ class $AssetsImagesIconsGen {
   List<SvgGenImage> get values => [dartTest, fuchsia, kmm, paint];
 }
 
-class BuildAssets {
-  const BuildAssets._();
+abstract final class BuildAssets {
 
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();
@@ -314,7 +320,8 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ?? (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
+      colorFilter: colorFilter ??
+          (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,
     );

--- a/packages/core/test_resources/actual_data/build_assets_build_runner_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_runner_assets.gen.dart
@@ -56,16 +56,13 @@ class $AssetsImagesGen {
   AssetGenImage get logo => const AssetGenImage('assets/images/logo.png');
 
   /// File path: assets/images/profile.jpg
-  AssetGenImage get profileJpg =>
-      const AssetGenImage('assets/images/profile.jpg');
+  AssetGenImage get profileJpg => const AssetGenImage('assets/images/profile.jpg');
 
   /// File path: assets/images/profile.png
-  AssetGenImage get profilePng =>
-      const AssetGenImage('assets/images/profile.png');
+  AssetGenImage get profilePng => const AssetGenImage('assets/images/profile.png');
 
   /// List of all assets
-  List<AssetGenImage> get values =>
-      [chip1, chip2, logo, profileJpg, profilePng];
+  List<AssetGenImage> get values => [chip1, chip2, logo, profileJpg, profilePng];
 }
 
 class $AssetsJsonGen {
@@ -105,8 +102,7 @@ class $AssetsImagesChip3Gen {
   const $AssetsImagesChip3Gen();
 
   /// File path: assets/images/chip3/chip3.jpg
-  AssetGenImage get chip3 =>
-      const AssetGenImage('assets/images/chip3/chip3.jpg');
+  AssetGenImage get chip3 => const AssetGenImage('assets/images/chip3/chip3.jpg');
 
   /// List of all assets
   List<AssetGenImage> get values => [chip3];
@@ -116,8 +112,7 @@ class $AssetsImagesChip4Gen {
   const $AssetsImagesChip4Gen();
 
   /// File path: assets/images/chip4/chip4.jpg
-  AssetGenImage get chip4 =>
-      const AssetGenImage('assets/images/chip4/chip4.jpg');
+  AssetGenImage get chip4 => const AssetGenImage('assets/images/chip4/chip4.jpg');
 
   /// List of all assets
   List<AssetGenImage> get values => [chip4];
@@ -127,12 +122,10 @@ class $AssetsImagesIconsGen {
   const $AssetsImagesIconsGen();
 
   /// File path: assets/images/icons/dart@test.svg
-  SvgGenImage get dartTest =>
-      const SvgGenImage('assets/images/icons/dart@test.svg');
+  SvgGenImage get dartTest => const SvgGenImage('assets/images/icons/dart@test.svg');
 
   /// File path: assets/images/icons/fuchsia.svg
-  SvgGenImage get fuchsia =>
-      const SvgGenImage('assets/images/icons/fuchsia.svg');
+  SvgGenImage get fuchsia => const SvgGenImage('assets/images/icons/fuchsia.svg');
 
   /// File path: assets/images/icons/kmm.svg
   SvgGenImage get kmm => const SvgGenImage('assets/images/icons/kmm.svg');
@@ -319,8 +312,7 @@ class SvgGenImage {
       placeholderBuilder: placeholderBuilder,
       semanticsLabel: semanticsLabel,
       excludeFromSemantics: excludeFromSemantics,
-      colorFilter: colorFilter ??
-          (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
+      colorFilter: colorFilter ?? (color == null ? null : ColorFilter.mode(color, colorBlendMode)),
       clipBehavior: clipBehavior,
       cacheColorFilter: cacheColorFilter,
     );

--- a/packages/core/test_resources/actual_data/build_assets_build_runner_assets.gen.dart
+++ b/packages/core/test_resources/actual_data/build_assets_build_runner_assets.gen.dart
@@ -145,7 +145,6 @@ class $AssetsImagesIconsGen {
 }
 
 abstract final class BuildAssets {
-
   static const String changelog = 'CHANGELOG.md';
   static const $AssetsFlareGen flare = $AssetsFlareGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
@@ -12,7 +12,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 abstract final class ColorName {
-
   /// Color: #000000
   static const Color black = Color(0xFF000000);
 

--- a/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
@@ -12,7 +12,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 class ColorName {
-  ColorName._();
+  const ColorName._();
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
@@ -11,8 +11,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
-class ColorName {
-  const ColorName._();
+abstract final class ColorName {
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);
@@ -30,17 +29,17 @@ class ColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-        50: Color(0xFFF9E5E5),
-        100: Color(0xFFF1BFBF),
-        200: Color(0xFFE79595),
-        300: Color(0xFFDD6A6A),
-        400: Color(0xFFD64A4A),
-        500: Color(0xFFCF2A2A),
-        600: Color(0xFFCA2525),
-        700: Color(0xFFC31F1F),
-        800: Color(0xFFBD1919),
-        900: Color(0xFFB20F0F),
-      });
+    50: Color(0xFFF9E5E5),
+    100: Color(0xFFF1BFBF),
+    200: Color(0xFFE79595),
+    300: Color(0xFFDD6A6A),
+    400: Color(0xFFD64A4A),
+    500: Color(0xFFCF2A2A),
+    600: Color(0xFFCA2525),
+    700: Color(0xFFC31F1F),
+    800: Color(0xFFBD1919),
+    900: Color(0xFFB20F0F),
+  });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -64,17 +63,17 @@ class ColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-        50: Color(0xFFFBF2E5),
-        100: Color(0xFFF5DFBE),
-        200: Color(0xFFEFCA93),
-        300: Color(0xFFE9B568),
-        400: Color(0xFFE4A547),
-        500: Color(0xFFDF9527),
-        600: Color(0xFFDB8D23),
-        700: Color(0xFFD7821D),
-        800: Color(0xFFD27817),
-        900: Color(0xFFCA670E),
-      });
+    50: Color(0xFFFBF2E5),
+    100: Color(0xFFF5DFBE),
+    200: Color(0xFFEFCA93),
+    300: Color(0xFFE9B568),
+    400: Color(0xFFE4A547),
+    500: Color(0xFFDF9527),
+    600: Color(0xFFDB8D23),
+    700: Color(0xFFD7821D),
+    800: Color(0xFFD27817),
+    900: Color(0xFFCA670E),
+  });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -83,9 +82,9 @@ class ColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-        100: Color(0xFFFFE8E0),
-        200: Color(0xFFFFBCA3),
-        400: Color(0xFFFFA989),
-        700: Color(0xFFFF9E7A),
-      });
+    100: Color(0xFFFFE8E0),
+    200: Color(0xFFFFBCA3),
+    400: Color(0xFFFFA989),
+    700: Color(0xFFFF9E7A),
+  });
 }

--- a/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_change_output_path.gen.dart
@@ -28,17 +28,17 @@ abstract final class ColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-    50: Color(0xFFF9E5E5),
-    100: Color(0xFFF1BFBF),
-    200: Color(0xFFE79595),
-    300: Color(0xFFDD6A6A),
-    400: Color(0xFFD64A4A),
-    500: Color(0xFFCF2A2A),
-    600: Color(0xFFCA2525),
-    700: Color(0xFFC31F1F),
-    800: Color(0xFFBD1919),
-    900: Color(0xFFB20F0F),
-  });
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -62,17 +62,17 @@ abstract final class ColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-    50: Color(0xFFFBF2E5),
-    100: Color(0xFFF5DFBE),
-    200: Color(0xFFEFCA93),
-    300: Color(0xFFE9B568),
-    400: Color(0xFFE4A547),
-    500: Color(0xFFDF9527),
-    600: Color(0xFFDB8D23),
-    700: Color(0xFFD7821D),
-    800: Color(0xFFD27817),
-    900: Color(0xFFCA670E),
-  });
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -81,9 +81,9 @@ abstract final class ColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-    100: Color(0xFFFFE8E0),
-    200: Color(0xFFFFBCA3),
-    400: Color(0xFFFFA989),
-    700: Color(0xFFFF9E7A),
-  });
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/colors_colors.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors.gen.dart
@@ -12,7 +12,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 abstract final class ColorName {
-
   /// Color: #000000
   static const Color black = Color(0xFF000000);
 

--- a/packages/core/test_resources/actual_data/colors_colors.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors.gen.dart
@@ -12,7 +12,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 class ColorName {
-  ColorName._();
+  const ColorName._();
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/packages/core/test_resources/actual_data/colors_colors.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors.gen.dart
@@ -11,8 +11,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
-class ColorName {
-  const ColorName._();
+abstract final class ColorName {
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
@@ -12,7 +12,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 class MyColorName {
-  MyColorName._();
+  const MyColorName._();
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
@@ -11,8 +11,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
-class MyColorName {
-  const MyColorName._();
+abstract final class MyColorName {
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);
@@ -30,17 +29,17 @@ class MyColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-        50: Color(0xFFF9E5E5),
-        100: Color(0xFFF1BFBF),
-        200: Color(0xFFE79595),
-        300: Color(0xFFDD6A6A),
-        400: Color(0xFFD64A4A),
-        500: Color(0xFFCF2A2A),
-        600: Color(0xFFCA2525),
-        700: Color(0xFFC31F1F),
-        800: Color(0xFFBD1919),
-        900: Color(0xFFB20F0F),
-      });
+    50: Color(0xFFF9E5E5),
+    100: Color(0xFFF1BFBF),
+    200: Color(0xFFE79595),
+    300: Color(0xFFDD6A6A),
+    400: Color(0xFFD64A4A),
+    500: Color(0xFFCF2A2A),
+    600: Color(0xFFCA2525),
+    700: Color(0xFFC31F1F),
+    800: Color(0xFFBD1919),
+    900: Color(0xFFB20F0F),
+  });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -64,17 +63,17 @@ class MyColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-        50: Color(0xFFFBF2E5),
-        100: Color(0xFFF5DFBE),
-        200: Color(0xFFEFCA93),
-        300: Color(0xFFE9B568),
-        400: Color(0xFFE4A547),
-        500: Color(0xFFDF9527),
-        600: Color(0xFFDB8D23),
-        700: Color(0xFFD7821D),
-        800: Color(0xFFD27817),
-        900: Color(0xFFCA670E),
-      });
+    50: Color(0xFFFBF2E5),
+    100: Color(0xFFF5DFBE),
+    200: Color(0xFFEFCA93),
+    300: Color(0xFFE9B568),
+    400: Color(0xFFE4A547),
+    500: Color(0xFFDF9527),
+    600: Color(0xFFDB8D23),
+    700: Color(0xFFD7821D),
+    800: Color(0xFFD27817),
+    900: Color(0xFFCA670E),
+  });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -83,9 +82,9 @@ class MyColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-        100: Color(0xFFFFE8E0),
-        200: Color(0xFFFFBCA3),
-        400: Color(0xFFFFA989),
-        700: Color(0xFFFF9E7A),
-      });
+    100: Color(0xFFFFE8E0),
+    200: Color(0xFFFFBCA3),
+    400: Color(0xFFFFA989),
+    700: Color(0xFFFF9E7A),
+  });
 }

--- a/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
@@ -12,7 +12,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 abstract final class MyColorName {
-
   /// Color: #000000
   static const Color black = Color(0xFF000000);
 

--- a/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_colors_change_class_name.gen.dart
@@ -28,17 +28,17 @@ abstract final class MyColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-    50: Color(0xFFF9E5E5),
-    100: Color(0xFFF1BFBF),
-    200: Color(0xFFE79595),
-    300: Color(0xFFDD6A6A),
-    400: Color(0xFFD64A4A),
-    500: Color(0xFFCF2A2A),
-    600: Color(0xFFCA2525),
-    700: Color(0xFFC31F1F),
-    800: Color(0xFFBD1919),
-    900: Color(0xFFB20F0F),
-  });
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -62,17 +62,17 @@ abstract final class MyColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-    50: Color(0xFFFBF2E5),
-    100: Color(0xFFF5DFBE),
-    200: Color(0xFFEFCA93),
-    300: Color(0xFFE9B568),
-    400: Color(0xFFE4A547),
-    500: Color(0xFFDF9527),
-    600: Color(0xFFDB8D23),
-    700: Color(0xFFD7821D),
-    800: Color(0xFFD27817),
-    900: Color(0xFFCA670E),
-  });
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -81,9 +81,9 @@ abstract final class MyColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-    100: Color(0xFFFFE8E0),
-    200: Color(0xFFFFBCA3),
-    400: Color(0xFFFFA989),
-    700: Color(0xFFFF9E7A),
-  });
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/colors_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_normal.gen.dart
@@ -11,8 +11,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
-class ColorName {
-  const ColorName._();
+abstract final class ColorName {
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);
@@ -42,17 +41,17 @@ class ColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-        50: Color(0xFFF9E5E5),
-        100: Color(0xFFF1BFBF),
-        200: Color(0xFFE79595),
-        300: Color(0xFFDD6A6A),
-        400: Color(0xFFD64A4A),
-        500: Color(0xFFCF2A2A),
-        600: Color(0xFFCA2525),
-        700: Color(0xFFC31F1F),
-        800: Color(0xFFBD1919),
-        900: Color(0xFFB20F0F),
-      });
+    50: Color(0xFFF9E5E5),
+    100: Color(0xFFF1BFBF),
+    200: Color(0xFFE79595),
+    300: Color(0xFFDD6A6A),
+    400: Color(0xFFD64A4A),
+    500: Color(0xFFCF2A2A),
+    600: Color(0xFFCA2525),
+    700: Color(0xFFC31F1F),
+    800: Color(0xFFBD1919),
+    900: Color(0xFFB20F0F),
+  });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -76,17 +75,17 @@ class ColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-        50: Color(0xFFFBF2E5),
-        100: Color(0xFFF5DFBE),
-        200: Color(0xFFEFCA93),
-        300: Color(0xFFE9B568),
-        400: Color(0xFFE4A547),
-        500: Color(0xFFDF9527),
-        600: Color(0xFFDB8D23),
-        700: Color(0xFFD7821D),
-        800: Color(0xFFD27817),
-        900: Color(0xFFCA670E),
-      });
+    50: Color(0xFFFBF2E5),
+    100: Color(0xFFF5DFBE),
+    200: Color(0xFFEFCA93),
+    300: Color(0xFFE9B568),
+    400: Color(0xFFE4A547),
+    500: Color(0xFFDF9527),
+    600: Color(0xFFDB8D23),
+    700: Color(0xFFD7821D),
+    800: Color(0xFFD27817),
+    900: Color(0xFFCA670E),
+  });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -95,9 +94,9 @@ class ColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-        100: Color(0xFFFFE8E0),
-        200: Color(0xFFFFBCA3),
-        400: Color(0xFFFFA989),
-        700: Color(0xFFFF9E7A),
-      });
+    100: Color(0xFFFFE8E0),
+    200: Color(0xFFFFBCA3),
+    400: Color(0xFFFFA989),
+    700: Color(0xFFFF9E7A),
+  });
 }

--- a/packages/core/test_resources/actual_data/colors_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_normal.gen.dart
@@ -40,17 +40,17 @@ abstract final class ColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-    50: Color(0xFFF9E5E5),
-    100: Color(0xFFF1BFBF),
-    200: Color(0xFFE79595),
-    300: Color(0xFFDD6A6A),
-    400: Color(0xFFD64A4A),
-    500: Color(0xFFCF2A2A),
-    600: Color(0xFFCA2525),
-    700: Color(0xFFC31F1F),
-    800: Color(0xFFBD1919),
-    900: Color(0xFFB20F0F),
-  });
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -74,17 +74,17 @@ abstract final class ColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-    50: Color(0xFFFBF2E5),
-    100: Color(0xFFF5DFBE),
-    200: Color(0xFFEFCA93),
-    300: Color(0xFFE9B568),
-    400: Color(0xFFE4A547),
-    500: Color(0xFFDF9527),
-    600: Color(0xFFDB8D23),
-    700: Color(0xFFD7821D),
-    800: Color(0xFFD27817),
-    900: Color(0xFFCA670E),
-  });
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -93,9 +93,9 @@ abstract final class ColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-    100: Color(0xFFFFE8E0),
-    200: Color(0xFFFFBCA3),
-    400: Color(0xFFFFA989),
-    700: Color(0xFFFF9E7A),
-  });
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/colors_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_normal.gen.dart
@@ -12,7 +12,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 abstract final class ColorName {
-
   /// Color: #000000
   static const Color black = Color(0xFF000000);
 

--- a/packages/core/test_resources/actual_data/colors_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_normal.gen.dart
@@ -12,7 +12,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 class ColorName {
-  ColorName._();
+  const ColorName._();
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
@@ -12,7 +12,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 abstract final class ColorName {
-
   /// Color: #000000
   static const Color black = Color(0xFF000000);
 

--- a/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
@@ -12,7 +12,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 class ColorName {
-  ColorName._();
+  const ColorName._();
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
@@ -11,8 +11,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
-class ColorName {
-  const ColorName._();
+abstract final class ColorName {
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);
@@ -30,17 +29,17 @@ class ColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-        50: Color(0xFFF9E5E5),
-        100: Color(0xFFF1BFBF),
-        200: Color(0xFFE79595),
-        300: Color(0xFFDD6A6A),
-        400: Color(0xFFD64A4A),
-        500: Color(0xFFCF2A2A),
-        600: Color(0xFFCA2525),
-        700: Color(0xFFC31F1F),
-        800: Color(0xFFBD1919),
-        900: Color(0xFFB20F0F),
-      });
+    50: Color(0xFFF9E5E5),
+    100: Color(0xFFF1BFBF),
+    200: Color(0xFFE79595),
+    300: Color(0xFFDD6A6A),
+    400: Color(0xFFD64A4A),
+    500: Color(0xFFCF2A2A),
+    600: Color(0xFFCA2525),
+    700: Color(0xFFC31F1F),
+    800: Color(0xFFBD1919),
+    900: Color(0xFFB20F0F),
+  });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -64,17 +63,17 @@ class ColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-        50: Color(0xFFFBF2E5),
-        100: Color(0xFFF5DFBE),
-        200: Color(0xFFEFCA93),
-        300: Color(0xFFE9B568),
-        400: Color(0xFFE4A547),
-        500: Color(0xFFDF9527),
-        600: Color(0xFFDB8D23),
-        700: Color(0xFFD7821D),
-        800: Color(0xFFD27817),
-        900: Color(0xFFCA670E),
-      });
+    50: Color(0xFFFBF2E5),
+    100: Color(0xFFF5DFBE),
+    200: Color(0xFFEFCA93),
+    300: Color(0xFFE9B568),
+    400: Color(0xFFE4A547),
+    500: Color(0xFFDF9527),
+    600: Color(0xFFDB8D23),
+    700: Color(0xFFD7821D),
+    800: Color(0xFFD27817),
+    900: Color(0xFFCA670E),
+  });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -83,9 +82,9 @@ class ColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-        100: Color(0xFFFFE8E0),
-        200: Color(0xFFFFBCA3),
-        400: Color(0xFFFFA989),
-        700: Color(0xFFFF9E7A),
-      });
+    100: Color(0xFFFFE8E0),
+    200: Color(0xFFFFBCA3),
+    400: Color(0xFFFFA989),
+    700: Color(0xFFFF9E7A),
+  });
 }

--- a/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_only_flutter_gen_value.gen.dart
@@ -28,17 +28,17 @@ abstract final class ColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-    50: Color(0xFFF9E5E5),
-    100: Color(0xFFF1BFBF),
-    200: Color(0xFFE79595),
-    300: Color(0xFFDD6A6A),
-    400: Color(0xFFD64A4A),
-    500: Color(0xFFCF2A2A),
-    600: Color(0xFFCA2525),
-    700: Color(0xFFC31F1F),
-    800: Color(0xFFBD1919),
-    900: Color(0xFFB20F0F),
-  });
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -62,17 +62,17 @@ abstract final class ColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-    50: Color(0xFFFBF2E5),
-    100: Color(0xFFF5DFBE),
-    200: Color(0xFFEFCA93),
-    300: Color(0xFFE9B568),
-    400: Color(0xFFE4A547),
-    500: Color(0xFFDF9527),
-    600: Color(0xFFDB8D23),
-    700: Color(0xFFD7821D),
-    800: Color(0xFFD27817),
-    900: Color(0xFFCA670E),
-  });
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -81,9 +81,9 @@ abstract final class ColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-    100: Color(0xFFFFE8E0),
-    200: Color(0xFFFFBCA3),
-    400: Color(0xFFFFA989),
-    700: Color(0xFFFF9E7A),
-  });
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
@@ -12,7 +12,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 abstract final class ColorName {
-
   /// Color: #000000
   static const Color black = Color(0xFF000000);
 

--- a/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
@@ -12,7 +12,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
 class ColorName {
-  ColorName._();
+  const ColorName._();
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);

--- a/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
@@ -11,8 +11,7 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter/material.dart';
 
-class ColorName {
-  const ColorName._();
+abstract final class ColorName {
 
   /// Color: #000000
   static const Color black = Color(0xFF000000);
@@ -30,17 +29,17 @@ class ColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-        50: Color(0xFFF9E5E5),
-        100: Color(0xFFF1BFBF),
-        200: Color(0xFFE79595),
-        300: Color(0xFFDD6A6A),
-        400: Color(0xFFD64A4A),
-        500: Color(0xFFCF2A2A),
-        600: Color(0xFFCA2525),
-        700: Color(0xFFC31F1F),
-        800: Color(0xFFBD1919),
-        900: Color(0xFFB20F0F),
-      });
+    50: Color(0xFFF9E5E5),
+    100: Color(0xFFF1BFBF),
+    200: Color(0xFFE79595),
+    300: Color(0xFFDD6A6A),
+    400: Color(0xFFD64A4A),
+    500: Color(0xFFCF2A2A),
+    600: Color(0xFFCA2525),
+    700: Color(0xFFC31F1F),
+    800: Color(0xFFBD1919),
+    900: Color(0xFFB20F0F),
+  });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -64,17 +63,17 @@ class ColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-        50: Color(0xFFFBF2E5),
-        100: Color(0xFFF5DFBE),
-        200: Color(0xFFEFCA93),
-        300: Color(0xFFE9B568),
-        400: Color(0xFFE4A547),
-        500: Color(0xFFDF9527),
-        600: Color(0xFFDB8D23),
-        700: Color(0xFFD7821D),
-        800: Color(0xFFD27817),
-        900: Color(0xFFCA670E),
-      });
+    50: Color(0xFFFBF2E5),
+    100: Color(0xFFF5DFBE),
+    200: Color(0xFFEFCA93),
+    300: Color(0xFFE9B568),
+    400: Color(0xFFE4A547),
+    500: Color(0xFFDF9527),
+    600: Color(0xFFDB8D23),
+    700: Color(0xFFD7821D),
+    800: Color(0xFFD27817),
+    900: Color(0xFFCA670E),
+  });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -83,9 +82,9 @@ class ColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-        100: Color(0xFFFFE8E0),
-        200: Color(0xFFFFBCA3),
-        400: Color(0xFFFFA989),
-        700: Color(0xFFFF9E7A),
-      });
+    100: Color(0xFFFFE8E0),
+    200: Color(0xFFFFBCA3),
+    400: Color(0xFFFFA989),
+    700: Color(0xFFFF9E7A),
+  });
 }

--- a/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/colors_wrong_output_path.gen.dart
@@ -28,17 +28,17 @@ abstract final class ColorName {
   ///   900: #FFB20F0F
   static const MaterialColor crimsonRed =
       MaterialColor(0xFFCF2A2A, <int, Color>{
-    50: Color(0xFFF9E5E5),
-    100: Color(0xFFF1BFBF),
-    200: Color(0xFFE79595),
-    300: Color(0xFFDD6A6A),
-    400: Color(0xFFD64A4A),
-    500: Color(0xFFCF2A2A),
-    600: Color(0xFFCA2525),
-    700: Color(0xFFC31F1F),
-    800: Color(0xFFBD1919),
-    900: Color(0xFFB20F0F),
-  });
+        50: Color(0xFFF9E5E5),
+        100: Color(0xFFF1BFBF),
+        200: Color(0xFFE79595),
+        300: Color(0xFFDD6A6A),
+        400: Color(0xFFD64A4A),
+        500: Color(0xFFCF2A2A),
+        600: Color(0xFFCA2525),
+        700: Color(0xFFC31F1F),
+        800: Color(0xFFBD1919),
+        900: Color(0xFFB20F0F),
+      });
 
   /// Color: #979797
   static const Color gray410 = Color(0xFF979797);
@@ -62,17 +62,17 @@ abstract final class ColorName {
   ///   900: #FFCA670E
   static const MaterialColor yellowOcher =
       MaterialColor(0xFFDF9527, <int, Color>{
-    50: Color(0xFFFBF2E5),
-    100: Color(0xFFF5DFBE),
-    200: Color(0xFFEFCA93),
-    300: Color(0xFFE9B568),
-    400: Color(0xFFE4A547),
-    500: Color(0xFFDF9527),
-    600: Color(0xFFDB8D23),
-    700: Color(0xFFD7821D),
-    800: Color(0xFFD27817),
-    900: Color(0xFFCA670E),
-  });
+        50: Color(0xFFFBF2E5),
+        100: Color(0xFFF5DFBE),
+        200: Color(0xFFEFCA93),
+        300: Color(0xFFE9B568),
+        400: Color(0xFFE4A547),
+        500: Color(0xFFDF9527),
+        600: Color(0xFFDB8D23),
+        700: Color(0xFFD7821D),
+        800: Color(0xFFD27817),
+        900: Color(0xFFCA670E),
+      });
 
   /// MaterialAccentColor:
   ///   100: #FFFFE8E0
@@ -81,9 +81,9 @@ abstract final class ColorName {
   ///   700: #FFFF9E7A
   static const MaterialAccentColor yellowOcherAccent =
       MaterialAccentColor(0xFFFFBCA3, <int, Color>{
-    100: Color(0xFFFFE8E0),
-    200: Color(0xFFFFBCA3),
-    400: Color(0xFFFFA989),
-    700: Color(0xFFFF9E7A),
-  });
+        100: Color(0xFFFFE8E0),
+        200: Color(0xFFFFBCA3),
+        400: Color(0xFFFFA989),
+        700: Color(0xFFFF9E7A),
+      });
 }

--- a/packages/core/test_resources/actual_data/fonts_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_change_output_path.gen.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
-  FontFamily._();
+  const FontFamily._();
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_change_output_path.gen.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class FontFamily {
-  const FontFamily._();
+abstract final class FontFamily {
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_change_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_change_output_path.gen.dart
@@ -9,7 +9,6 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 abstract final class FontFamily {
-
   /// Font family: Raleway
   static const String raleway = 'Raleway';
 }

--- a/packages/core/test_resources/actual_data/fonts_fonts.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts.gen.dart
@@ -9,7 +9,6 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 abstract final class FontFamily {
-
   /// Font family: Raleway
   static const String raleway = 'Raleway';
 

--- a/packages/core/test_resources/actual_data/fonts_fonts.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts.gen.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
-  FontFamily._();
+  const FontFamily._();
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_fonts.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts.gen.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class FontFamily {
-  const FontFamily._();
+abstract final class FontFamily {
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_fonts_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts_change_class_name.gen.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class MyFontFamily {
-  const MyFontFamily._();
+abstract final class MyFontFamily {
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_fonts_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts_change_class_name.gen.dart
@@ -9,7 +9,6 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 abstract final class MyFontFamily {
-
   /// Font family: Raleway
   static const String raleway = 'Raleway';
 }

--- a/packages/core/test_resources/actual_data/fonts_fonts_change_class_name.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts_change_class_name.gen.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class MyFontFamily {
-  MyFontFamily._();
+  const MyFontFamily._();
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_fonts_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts_package_parameter.gen.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class FontFamily {
-  const FontFamily._();
+abstract final class FontFamily {
 
   static const String package = 'test';
 

--- a/packages/core/test_resources/actual_data/fonts_fonts_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts_package_parameter.gen.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
-  FontFamily._();
+  const FontFamily._();
 
   static const String package = 'test';
 

--- a/packages/core/test_resources/actual_data/fonts_fonts_package_parameter.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_fonts_package_parameter.gen.dart
@@ -9,7 +9,6 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 abstract final class FontFamily {
-
   static const String package = 'test';
 
   /// Font family: Raleway

--- a/packages/core/test_resources/actual_data/fonts_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_normal.gen.dart
@@ -9,7 +9,6 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 abstract final class FontFamily {
-
   /// Font family: Raleway
   static const String raleway = 'Raleway';
 

--- a/packages/core/test_resources/actual_data/fonts_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_normal.gen.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
-  FontFamily._();
+  const FontFamily._();
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_normal.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_normal.gen.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class FontFamily {
-  const FontFamily._();
+abstract final class FontFamily {
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_only_flutter_value.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_only_flutter_value.gen.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
-  FontFamily._();
+  const FontFamily._();
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_only_flutter_value.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_only_flutter_value.gen.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class FontFamily {
-  const FontFamily._();
+abstract final class FontFamily {
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_only_flutter_value.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_only_flutter_value.gen.dart
@@ -9,7 +9,6 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 abstract final class FontFamily {
-
   /// Font family: Raleway
   static const String raleway = 'Raleway';
 }

--- a/packages/core/test_resources/actual_data/fonts_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_wrong_output_path.gen.dart
@@ -9,7 +9,7 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 class FontFamily {
-  FontFamily._();
+  const FontFamily._();
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_wrong_output_path.gen.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class FontFamily {
-  const FontFamily._();
+abstract final class FontFamily {
 
   /// Font family: Raleway
   static const String raleway = 'Raleway';

--- a/packages/core/test_resources/actual_data/fonts_wrong_output_path.gen.dart
+++ b/packages/core/test_resources/actual_data/fonts_wrong_output_path.gen.dart
@@ -9,7 +9,6 @@
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 abstract final class FontFamily {
-
   /// Font family: Raleway
   static const String raleway = 'Raleway';
 }

--- a/packages/runner/test/workspace_build_test.dart
+++ b/packages/runner/test/workspace_build_test.dart
@@ -5,141 +5,145 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
-  test('supports build_runner --workspace and cleans stale outputs', () async {
-    final workspaceDir = await _createWorkspaceFixture();
-    addTearDown(() async {
-      if (workspaceDir.existsSync()) {
-        workspaceDir.deleteSync(recursive: true);
-      }
-    });
+  test(
+    'supports build_runner --workspace and cleans stale outputs',
+    () async {
+      final workspaceDir = await _createWorkspaceFixture();
+      addTearDown(() async {
+        if (workspaceDir.existsSync()) {
+          workspaceDir.deleteSync(recursive: true);
+        }
+      });
 
-    await _runProcess(
-      'flutter',
-      ['pub', 'get'],
-      workingDirectory: workspaceDir.path,
-    );
+      await _runProcess(
+        'flutter',
+        ['pub', 'get'],
+        workingDirectory: workspaceDir.path,
+      );
 
-    await _runProcess(
-      'dart',
-      [
-        'run',
-        'build_runner',
-        'build',
-        '--workspace',
-        '--delete-conflicting-outputs',
-      ],
-      workingDirectory: workspaceDir.path,
-    );
+      await _runProcess(
+        'dart',
+        [
+          'run',
+          'build_runner',
+          'build',
+          '--workspace',
+          '--delete-conflicting-outputs',
+        ],
+        workingDirectory: workspaceDir.path,
+      );
 
-    final appDir = Directory(p.join(workspaceDir.path, 'packages', 'app'));
-    final ownerFile = File(
-      p.join(
-        appDir.path,
-        '.dart_tool',
-        'flutter_build',
-        'flutter_gen',
-        'flutter_gen_owner.json',
-      ),
-    );
+      final appDir = Directory(p.join(workspaceDir.path, 'packages', 'app'));
+      final ownerFile = File(
+        p.join(
+          appDir.path,
+          '.dart_tool',
+          'flutter_build',
+          'flutter_gen',
+          'flutter_gen_owner.json',
+        ),
+      );
 
-    expect(
-      File(p.join(appDir.path, 'lib', 'gen', 'assets.gen.dart')).existsSync(),
-      isTrue,
-    );
-    expect(
-      File(p.join(appDir.path, 'lib', 'gen', 'colors.gen.dart')).existsSync(),
-      isTrue,
-    );
-    expect(
-      File(p.join(appDir.path, 'lib', 'gen', 'fonts.gen.dart')).existsSync(),
-      isTrue,
-    );
-    expect(ownerFile.existsSync(), isTrue);
+      expect(
+        File(p.join(appDir.path, 'lib', 'gen', 'assets.gen.dart')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(appDir.path, 'lib', 'gen', 'colors.gen.dart')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(appDir.path, 'lib', 'gen', 'fonts.gen.dart')).existsSync(),
+        isTrue,
+      );
+      expect(ownerFile.existsSync(), isTrue);
 
-    final initialOwner =
-        jsonDecode(ownerFile.readAsStringSync()) as Map<String, Object?>;
-    expect(
-      initialOwner['paths'],
-      containsAll([
-        'lib/gen/assets.gen.dart',
-        'lib/gen/colors.gen.dart',
-        'lib/gen/fonts.gen.dart',
-      ]),
-    );
+      final initialOwner =
+          jsonDecode(ownerFile.readAsStringSync()) as Map<String, Object?>;
+      expect(
+        initialOwner['paths'],
+        containsAll([
+          'lib/gen/assets.gen.dart',
+          'lib/gen/colors.gen.dart',
+          'lib/gen/fonts.gen.dart',
+        ]),
+      );
 
-    final appPubspec = File(p.join(appDir.path, 'pubspec.yaml'));
-    appPubspec.writeAsStringSync(
-      appPubspec
-          .readAsStringSync()
-          .replaceFirst('output: lib/gen/', 'output: lib/alt_gen/'),
-    );
+      final appPubspec = File(p.join(appDir.path, 'pubspec.yaml'));
+      appPubspec.writeAsStringSync(
+        appPubspec
+            .readAsStringSync()
+            .replaceFirst('output: lib/gen/', 'output: lib/alt_gen/'),
+      );
 
-    await _runProcess(
-      'dart',
-      [
-        'run',
-        'build_runner',
-        'build',
-        '--workspace',
-        '--delete-conflicting-outputs',
-      ],
-      workingDirectory: workspaceDir.path,
-    );
+      await _runProcess(
+        'dart',
+        [
+          'run',
+          'build_runner',
+          'build',
+          '--workspace',
+          '--delete-conflicting-outputs',
+        ],
+        workingDirectory: workspaceDir.path,
+      );
 
-    expect(
-      File(p.join(appDir.path, 'lib', 'gen', 'assets.gen.dart')).existsSync(),
-      isFalse,
-    );
-    expect(
-      File(p.join(appDir.path, 'lib', 'gen', 'colors.gen.dart')).existsSync(),
-      isFalse,
-    );
-    expect(
-      File(p.join(appDir.path, 'lib', 'gen', 'fonts.gen.dart')).existsSync(),
-      isFalse,
-    );
+      expect(
+        File(p.join(appDir.path, 'lib', 'gen', 'assets.gen.dart')).existsSync(),
+        isFalse,
+      );
+      expect(
+        File(p.join(appDir.path, 'lib', 'gen', 'colors.gen.dart')).existsSync(),
+        isFalse,
+      );
+      expect(
+        File(p.join(appDir.path, 'lib', 'gen', 'fonts.gen.dart')).existsSync(),
+        isFalse,
+      );
 
-    expect(
-      File(p.join(appDir.path, 'lib', 'alt_gen', 'assets.gen.dart'))
-          .existsSync(),
-      isTrue,
-    );
-    expect(
-      File(p.join(appDir.path, 'lib', 'alt_gen', 'colors.gen.dart'))
-          .existsSync(),
-      isTrue,
-    );
-    expect(
-      File(p.join(appDir.path, 'lib', 'alt_gen', 'fonts.gen.dart'))
-          .existsSync(),
-      isTrue,
-    );
+      expect(
+        File(p.join(appDir.path, 'lib', 'alt_gen', 'assets.gen.dart'))
+            .existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(appDir.path, 'lib', 'alt_gen', 'colors.gen.dart'))
+            .existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(appDir.path, 'lib', 'alt_gen', 'fonts.gen.dart'))
+            .existsSync(),
+        isTrue,
+      );
 
-    final updatedOwner =
-        jsonDecode(ownerFile.readAsStringSync()) as Map<String, Object?>;
-    expect(
-      updatedOwner['paths'],
-      containsAll([
-        'lib/alt_gen/assets.gen.dart',
-        'lib/alt_gen/colors.gen.dart',
-        'lib/alt_gen/fonts.gen.dart',
-      ]),
-    );
-  },
+      final updatedOwner =
+          jsonDecode(ownerFile.readAsStringSync()) as Map<String, Object?>;
+      expect(
+        updatedOwner['paths'],
+        containsAll([
+          'lib/alt_gen/assets.gen.dart',
+          'lib/alt_gen/colors.gen.dart',
+          'lib/alt_gen/fonts.gen.dart',
+        ]),
+      );
+    },
     timeout: const Timeout(Duration(minutes: 5)),
   );
 
-  test('applies package build.yaml options in workspace mode', () async {
-    final workspaceDir = await _createWorkspaceFixture();
-    addTearDown(() async {
-      if (workspaceDir.existsSync()) {
-        workspaceDir.deleteSync(recursive: true);
-      }
-    });
+  test(
+    'applies package build.yaml options in workspace mode',
+    () async {
+      final workspaceDir = await _createWorkspaceFixture();
+      addTearDown(() async {
+        if (workspaceDir.existsSync()) {
+          workspaceDir.deleteSync(recursive: true);
+        }
+      });
 
-    final appDir = Directory(p.join(workspaceDir.path, 'packages', 'app'));
-    final appBuildYaml = File(p.join(appDir.path, 'build.yaml'));
-    appBuildYaml.writeAsStringSync(r'''
+      final appDir = Directory(p.join(workspaceDir.path, 'packages', 'app'));
+      final appBuildYaml = File(p.join(appDir.path, 'build.yaml'));
+      appBuildYaml.writeAsStringSync(r'''
 targets:
   $default:
     builders:
@@ -148,87 +152,89 @@ targets:
           output: lib/build_gen/
 ''');
 
-    await _runProcess(
-      'flutter',
-      ['pub', 'get'],
-      workingDirectory: workspaceDir.path,
-    );
+      await _runProcess(
+        'flutter',
+        ['pub', 'get'],
+        workingDirectory: workspaceDir.path,
+      );
 
-    await _runProcess(
-      'dart',
-      [
-        'run',
-        'build_runner',
-        'build',
-        '--workspace',
-        '--delete-conflicting-outputs',
-      ],
-      workingDirectory: workspaceDir.path,
-    );
+      await _runProcess(
+        'dart',
+        [
+          'run',
+          'build_runner',
+          'build',
+          '--workspace',
+          '--delete-conflicting-outputs',
+        ],
+        workingDirectory: workspaceDir.path,
+      );
 
-    expect(
-      File(p.join(appDir.path, 'lib', 'build_gen', 'assets.gen.dart'))
-          .existsSync(),
-      isTrue,
-    );
-    expect(
-      File(p.join(appDir.path, 'lib', 'build_gen', 'colors.gen.dart'))
-          .existsSync(),
-      isTrue,
-    );
-    expect(
-      File(p.join(appDir.path, 'lib', 'build_gen', 'fonts.gen.dart'))
-          .existsSync(),
-      isTrue,
-    );
+      expect(
+        File(p.join(appDir.path, 'lib', 'build_gen', 'assets.gen.dart'))
+            .existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(appDir.path, 'lib', 'build_gen', 'colors.gen.dart'))
+            .existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(appDir.path, 'lib', 'build_gen', 'fonts.gen.dart'))
+            .existsSync(),
+        isTrue,
+      );
 
-    expect(
-      File(p.join(appDir.path, 'lib', 'gen', 'assets.gen.dart')).existsSync(),
-      isFalse,
-    );
-  },
+      expect(
+        File(p.join(appDir.path, 'lib', 'gen', 'assets.gen.dart')).existsSync(),
+        isFalse,
+      );
+    },
     timeout: const Timeout(Duration(minutes: 5)),
   );
 
-  test('overwrites existing generated files in workspace mode', () async {
-    final workspaceDir = await _createWorkspaceFixture();
-    addTearDown(() async {
-      if (workspaceDir.existsSync()) {
-        workspaceDir.deleteSync(recursive: true);
-      }
-    });
+  test(
+    'overwrites existing generated files in workspace mode',
+    () async {
+      final workspaceDir = await _createWorkspaceFixture();
+      addTearDown(() async {
+        if (workspaceDir.existsSync()) {
+          workspaceDir.deleteSync(recursive: true);
+        }
+      });
 
-    final appDir = Directory(p.join(workspaceDir.path, 'packages', 'app'));
-    final generatedFile = File(
-      p.join(appDir.path, 'lib', 'gen', 'assets.gen.dart'),
-    );
-    generatedFile.parent.createSync(recursive: true);
-    generatedFile.writeAsStringSync('// stale contents\n');
+      final appDir = Directory(p.join(workspaceDir.path, 'packages', 'app'));
+      final generatedFile = File(
+        p.join(appDir.path, 'lib', 'gen', 'assets.gen.dart'),
+      );
+      generatedFile.parent.createSync(recursive: true);
+      generatedFile.writeAsStringSync('// stale contents\n');
 
-    await _runProcess(
-      'flutter',
-      ['pub', 'get'],
-      workingDirectory: workspaceDir.path,
-    );
+      await _runProcess(
+        'flutter',
+        ['pub', 'get'],
+        workingDirectory: workspaceDir.path,
+      );
 
-    await _runProcess(
-      'dart',
-      [
-        'run',
-        'build_runner',
-        'build',
-        '--workspace',
-        '--delete-conflicting-outputs',
-      ],
-      workingDirectory: workspaceDir.path,
-    );
+      await _runProcess(
+        'dart',
+        [
+          'run',
+          'build_runner',
+          'build',
+          '--workspace',
+          '--delete-conflicting-outputs',
+        ],
+        workingDirectory: workspaceDir.path,
+      );
 
-    expect(generatedFile.existsSync(), isTrue);
-    expect(
-      generatedFile.readAsStringSync(),
-      isNot(contains('// stale contents')),
-    );
-  },
+      expect(generatedFile.existsSync(), isTrue);
+      expect(
+        generatedFile.readAsStringSync(),
+        isNot(contains('// stale contents')),
+      );
+    },
     timeout: const Timeout(Duration(minutes: 5)),
   );
 }


### PR DESCRIPTION
## What does this change?

Uses `abstract final` class modifier for generated classes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run test`)
  - [ ] Ensure the analyzer and formatter pass (`melos run format` to automatically apply formatting)
- [ ] Appropriate docs were updated (if necessary)

