### PR TITLE
upgrade: update flutter to 3.44.4, ignore rive in renovate

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.41.1-stable
+flutter 3.44.4-stable

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   "branchPrefix": "upgrade-renovate-",
   "dependencyDashboard": false,
   "ignorePaths": [".github/", "examples/**"],
+  "ignoreDeps": ["rive"],
   "major": {
     "minimumReleaseAge": "30 days"
   },


### PR DESCRIPTION
## Changes

- **Flutter 3.44.4**: Updates `.tool-versions` from `3.41.1-stable` to `3.44.4-stable` (supersedes #762 which was at 3.44.2)
- **Ignore rive**: Adds `rive` to `ignoreDeps` in `renovate.json` (closes #746)

Closes #762
Closes #746