### PR TITLE
Support package_config 3.0.0

### DIFF
--- a/packages/runner/pubspec.yaml
+++ b/packages/runner/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   collection: ^1.17.0
   crypto: ^3.0.0
   glob: ^2.0.0
-  package_config: ^2.1.0
+  package_config: '>=2.2.0 <4.0.0'
   path: ^1.8.0
   yaml: ^3.0.0
 


### PR DESCRIPTION
## What does this change?

Updates the `package_config` dependency constraint in `flutter_gen_runner` from `^2.1.0` to `>=2.2.0 <4.0.0`.

Previously, projects using `package_config` 3.0.0 could not use `flutter_gen_runner` 5.15.0 because its dependency constraint only allowed `package_config` 2.x:

> Because `flutter_gen_runner 5.15.0` depends on `package_config ^2.1.0` and the project depends on `package_config 3.0.0`, version solving failed.

The updated constraint resolves this dependency conflict while preserving compatibility with `package_config` 2.2.x.

No new dependencies are introduced.

Fixes #783 🎯

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
  - [x] Ensure the tests (`melos run test`)
  - [x] Ensure the analyzer and formatter pass (`melos run format`)
- [x] Appropriate docs were updated (if necessary)

Same as https://github.com/FlutterGen/flutter_gen/pull/775